### PR TITLE
Add remaining audit jsons

### DIFF
--- a/0_json_functions.R
+++ b/0_json_functions.R
@@ -339,7 +339,7 @@ export_audit_graph_json <- function(audit_file__, export_path_full) {
   chart_information <- paste0(chart_information, json_tail)
   chart_legend <- paste0(chart_legend, json_tail)
 
-  write(chart_legend, file = paste0(export_path_full, ".json"))
+  write(chart_legend, file = paste0(export_path_full, "legend.json"))
   write(chart_information, file = paste0(export_path_full, ".json"))
 }
 

--- a/integration-test.Rmd
+++ b/integration-test.Rmd
@@ -38,6 +38,11 @@ library(here)
 library(conflicted)
 conflicted::conflict_prefer("filter", "dplyr")
 conflicted::conflict_prefer("lag", "dplyr")
+conflicted::conflict_prefer("mutate", "dplyr")
+conflicted::conflict_prefer("here", "here")
+conflicted::conflict_prefer("rename", "dplyr") 
+conflicted::conflict_prefer("summarise", "dplyr")
+conflicted::conflict_prefer("arrange", "dplyr")
 ```
 
 All packages detected in the directory PACTA\_analysis:


### PR DESCRIPTION
This PR:

- corrects the output path of one of the json files generated for the audit file.
- previously its name was a duplicate and the output therefore overwritten