### PR TITLE
update list of needed pkgs

### DIFF
--- a/bin/run-r-scripts
+++ b/bin/run-r-scripts
@@ -9,7 +9,7 @@ cd /bound
 echo 'options(repos = c(CRAN = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest"))' >> ~/.Rprofile
 echo 'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))' >> ~/.Rprofile
 # Rscript -e "update.packages(ask = FALSE)"
-Rscript -e "pkgs_to_install <- c('conflicted', 'here', 'writexl', 'countrycode', 'renv', 'tibble', 'stringr', 'zoo', 'data.table', 'cowplot', 'ggforce', 'ggrepel', 'sitools'); install.packages(setdiff(pkgs_to_install, installed.packages()))"
+Rscript -e 'pkgs_to_install <- c("assertthat", "bookdown", "config", "conflicted", "countrycode", "data.table", "devtools", "dplyr", "forcats", "fs", "fst", "ggplot2", "glue", "here", "highcharter", "janitor", "jsonlite", "knitr", "purrr", "readr", "readxl", "renv", "reshape2", "rlang", "rmarkdown", "rstudioapi", "scales", "stringr", "testthat", "tibble", "tidyr", "tidyselect", "usethis", "withr", "writexl", "zoo"); install.packages(setdiff(pkgs_to_install, installed.packages()))'
 # FIXME: TestPortfolio_Input should be a parameter
 Rscript --vanilla web_tool_script_1.R TestPortfolio_Input \
   && Rscript --vanilla web_tool_script_2.R TestPortfolio_Input \


### PR DESCRIPTION
Now that we have a docker image that has all of the necessary pkgs pre-installed **and** that I previously modified the `install.packages` command in this file, I think it's best to also have here the same complete list of necessary pkgs to install. Which leads to two possible scenarios....

1. case: you use the default `2dii/r-packages:latest` docker image, or another docker image that already has all of the pkgs needed installed; result: this command will skip installing anything because all of these will already be installed, so this will remain a quick start-up

2. case: you use some alternate docker image that does *not* already have all of the needed pkgs installed; result this command will force the docker instance to install any (but only) pkgs that are need and are not already installed so that the other scripts can finish successfully