### PR TITLE
set ST shock year to 2030

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -242,7 +242,7 @@ peers_bonds_results_user <- read_rds(file.path(data_location_ext, "Peers_bonds_r
 
 
 translation_list <- readr::read_csv(path(template_path, "translation_list.csv"), col_types = cols())
-shock_year <- 2028 # this should come directly from the stress test
+shock_year <- 2030 # this should come directly from the stress test.. 2030 based on current discussions in CHPA2020 case
 pacta_sectors_not_analysed <- c("Aviation","Cement","Shipping","Steel")
 
 create_interactive_report(


### PR DESCRIPTION
closes https://github.com/2DegreesInvesting/PACTA_analysis/issues/243

while this should be moved to the stress testing repo and returned from there at some point, for the time beong the change happens here.
2030 as a shock year is based on current discussions for Pacta 2020 Switzerland and reviewing first results

follow up is found here: https://github.com/2DegreesInvesting/StressTestingModelDev/issues/67