### PR TITLE
stop_on_error() helps stop test_r_scripts()

### DIFF
--- a/R/test_r_scripts.R
+++ b/R/test_r_scripts.R
@@ -15,7 +15,7 @@ r_script_command <- function(x) {
 
 stop_on_error <- function(exit_code) {
   if (exit_code > 0) {
-    stop("This script throwed an error.", call. = FALSE)
+    stop("This script threw an error.", call. = FALSE)
   }
 
   invisible(exit_code)

--- a/R/test_r_scripts.R
+++ b/R/test_r_scripts.R
@@ -3,7 +3,7 @@ test_r_scripts <- function(x = 1:3) {
 
   for (i in seq_along(command)) {
     message("Testing: ", command[[i]])
-    stop_on_error(system(command[[i]]), i)
+    stop_on_error(system(command[[i]]))
   }
 
   invisible(x)

--- a/R/test_r_scripts.R
+++ b/R/test_r_scripts.R
@@ -13,9 +13,9 @@ r_script_command <- function(x) {
   sprintf("Rscript --vanilla web_tool_script_%s.R TestPortfolio_Input", x)
 }
 
-stop_on_error <- function(exit_code, script_id) {
+stop_on_error <- function(exit_code) {
   if (exit_code > 0) {
-    stop("Script ", script_id, " throwed an error.", call. = FALSE)
+    stop("This script throwed an error.", call. = FALSE)
   }
 
   invisible(exit_code)

--- a/R/test_r_scripts.R
+++ b/R/test_r_scripts.R
@@ -3,7 +3,7 @@ test_r_scripts <- function(x = 1:3) {
 
   for (i in seq_along(command)) {
     message("Testing: ", command[[i]])
-    system(command[[i]])
+    stop_on_error(system(command[[i]]), i)
   }
 
   invisible(x)
@@ -11,4 +11,12 @@ test_r_scripts <- function(x = 1:3) {
 
 r_script_command <- function(x) {
   sprintf("Rscript --vanilla web_tool_script_%s.R TestPortfolio_Input", x)
+}
+
+stop_on_error <- function(exit_code, script_id) {
+  if (exit_code > 0) {
+    stop("Script ", script_id, " throwed an error.", call. = FALSE)
+  }
+
+  invisible(exit_code)
 }

--- a/tests/testthat/test-test_r_scripts.R
+++ b/tests/testthat/test-test_r_scripts.R
@@ -1,7 +1,6 @@
 test_that("stop_on_error stops on error", {
-  expect_error(stop_on_error(exit_code = 0, script_id = 1), NA)
-  expect_error(stop_on_error(exit_code = -1, script_id = 2), NA)
-  expect_error(stop_on_error(exit_code = 1, script_id = 1), "1.*error")
-  expect_error(stop_on_error(exit_code = 1, script_id = 99), "99.*error")
-  expect_error(stop_on_error(exit_code = 3, script_id = 2), "2.*error")
+  expect_error(stop_on_error(exit_code = 0), NA)
+  expect_error(stop_on_error(exit_code = -1), NA)
+  expect_error(stop_on_error(exit_code = 1), "error")
+  expect_error(stop_on_error(exit_code = 99), "error")
 })

--- a/tests/testthat/test-test_r_scripts.R
+++ b/tests/testthat/test-test_r_scripts.R
@@ -1,0 +1,7 @@
+test_that("stop_on_error stops on error", {
+  expect_error(stop_on_error(exit_code = 0, script_id = 1), NA)
+  expect_error(stop_on_error(exit_code = -1, script_id = 2), NA)
+  expect_error(stop_on_error(exit_code = 1, script_id = 1), "1.*error")
+  expect_error(stop_on_error(exit_code = 1, script_id = 99), "99.*error")
+  expect_error(stop_on_error(exit_code = 3, script_id = 2), "2.*error")
+})


### PR DESCRIPTION
Closes #237 
NOTE: When squash-merging please remove the message of bc134a2 -- I 
included a diff by accident.

`test_r_scripts()` now stops at the end of the first script that exits with status > 0.

``` r
devtools::load_all()
#> Loading PACTA.analysis

test_r_scripts(1:3)
#> Testing: Rscript --vanilla web_tool_script_1.R TestPortfolio_Input
#> Error: This script throwed an error.
```

<sup>Created on 2020-10-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

And we now gain the behaviour we expected when pandoc is unavailable:

![](https://i.imgur.com/6hJekrD.png)
-- https://github.com/2DegreesInvesting/PACTA_analysis/pull/261/checks?check_run_id=1310972774