### PR TITLE
Rm unnecessary files

### DIFF
--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -246,7 +246,7 @@ check_input_file_contents <- function(portfolio_, portfolio_name, investor_name)
   return(portfolio_clean)
 }
 
-website_text <- function(audit_file) {
+website_text <- function(audit_file, proc_input_path) {
   PortValues <- audit_file %>%
     ungroup() %>%
     filter(valid_input == TRUE) %>%
@@ -276,7 +276,7 @@ website_text <- function(audit_file) {
                 The remainder of the holdings are in asset classes outside the scope of this analysis.
                 For more information as to how each holding is classified, review the chart and audit file below.")
 
-  write(text, file.path(proc_input_path, "Websitetext.txt"))
+  write(text, file = file.path(proc_input_path, "Websitetext.txt"))
 }
 
 save_cleaned_files <- function(save_loc,

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -155,9 +155,9 @@ proc_input_path_ <- file.path(proc_input_path, portfolio_name_ref_all)
 
 # write_csv(file_names, file.path(proc_input_path_, "file_names.csv"))
 
-create_audit_chart(audit_file, proc_input_path = proc_input_path_)
+# create_audit_chart(audit_file, proc_input_path = proc_input_path_)
 
-website_text(audit_file, proc_input_path = proc_input_path_)
+# website_text(audit_file, proc_input_path = proc_input_path_)
 
 export_audit_information_jsons(
   audit_file_ = audit_file %>% filter(portfolio_name == portfolio_name),

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -125,10 +125,6 @@ identify_missing_data(portfolio_total)
 
 audit_file <- create_audit_file(portfolio_total)
 
-create_audit_chart(audit_file, proc_input_path)
-
-website_text(audit_file)
-
 emissions_totals <- calculate_portfolio_emissions(
   inc_emission_factors,
   audit_file,
@@ -159,6 +155,9 @@ proc_input_path_ <- file.path(proc_input_path, portfolio_name_ref_all)
 
 # write_csv(file_names, file.path(proc_input_path_, "file_names.csv"))
 
+create_audit_chart(audit_file, proc_input_path = proc_input_path_)
+
+website_text(audit_file, proc_input_path = proc_input_path_)
 
 export_audit_information_jsons(
   audit_file_ = audit_file %>% filter(portfolio_name == portfolio_name),


### PR DESCRIPTION
This PR:
- corrects file paths for `create_audit_chart()` and `website_text()`
- comments out function calls in webtool script 1 that write files we do not need in the web tool
- this ensure we do not overwrite these outputs for diff portfolios in production

closes: https://github.com/2DegreesInvesting/PACTA_analysis/issues/271