### PR TITLE
Scenario data updates

### DIFF
--- a/0_portfolio_test.R
+++ b/0_portfolio_test.R
@@ -115,7 +115,7 @@ aggregate_company <- function(df) {
     df <- df %>%
       ungroup() %>%
       select(
-        all_of(grouping_variables), scenario_source, scenario, allocation,
+        all_of(grouping_variables), scenario, allocation,
         id, company_name, financial_sector, port_weight,
         allocation_weight, plan_br_dist_alloc_wt, scen_br_dist_alloc_wt,
         equity_market, scenario_geography, year,
@@ -124,7 +124,7 @@ aggregate_company <- function(df) {
         scen_tech_prod, scen_alloc_wt_tech_prod, scen_carsten, scen_emission_factor
       ) %>%
       group_by(
-        !!!rlang::syms(grouping_variables), scenario_source, scenario, allocation,
+        !!!rlang::syms(grouping_variables), scenario, allocation,
         id, company_name, financial_sector,
         allocation_weight, plan_br_dist_alloc_wt, scen_br_dist_alloc_wt,
         equity_market, scenario_geography, year,
@@ -161,14 +161,14 @@ aggregate_portfolio <- function(df) {
   if (data_check(df)) {
     df <- df %>%
       select(
-        all_of(grouping_variables), scenario_source, scenario, allocation,
+        all_of(grouping_variables), scenario, allocation,
         equity_market, scenario_geography, year,
         ald_sector, technology,
         plan_tech_prod, plan_alloc_wt_tech_prod, plan_carsten, plan_emission_factor,
         scen_tech_prod, scen_alloc_wt_tech_prod, scen_carsten, scen_emission_factor
       ) %>%
       group_by(
-        !!!rlang::syms(grouping_variables), scenario_source, scenario, allocation,
+        !!!rlang::syms(grouping_variables), scenario, allocation,
         equity_market, scenario_geography, year,
         ald_sector, technology
       ) %>%

--- a/parameter_files/AnalysisParameters.yml
+++ b/parameter_files/AnalysisParameters.yml
@@ -53,31 +53,12 @@ default:
     Scenario.Sources.List:
       - ETP2017
       - WEO2019
-      - SBTI  
+      - WEO2020
+      - GECO2019
     Scenario.Geography.List:
       - Global
       - GlobalAggregate
       - NonOECD
       - OECD
-  Reporting:
-   Naming: 
-      GraphType: Report
-      Scenariochoose: SDS
-      AccountingPrinciple: PortfolioWeight
-      ScenarioGeographyChoose: GlobalAggregate
-      EquityMarketSelection: Global
-      Language: "EN"
-      Startyear: 2020
-      
-      
-   Benchmarks:
-      PeerGroupSelection: Project
-      EQPeersRef: Project
-      CBPeersRef: Project
-      eq_market_ref: GlobalMarket	
-      cb_market_ref: GlobalMarket
-
-   Contents:
-      templateversion: "GeneralTemplateInput_v6"
-      No.Companies: 15
+ 
 

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -36,7 +36,7 @@ real_estate_dir <- path(user_results_path, project_code, "real_estate")
 
 output_dir <- file.path(outputs_path, portfolio_name_ref_all)
 
-scenario <- "SDS"
+scenario <- "WEO2019_SDS"
 portfolio_allocation_method <- "portfolio_weight"
 scenario_geography <- "Global"
 audit_file <- read_csv(file.path(proc_input_path, portfolio_name, "audit_file.csv"), col_types = cols())
@@ -229,21 +229,12 @@ if (file.exists(file.path(results_path, portfolio_name, "Stress_test_results_IPR
   )
 }
 
-
 indices_equity_results_portfolio <- read_rds(file.path(data_location_ext, "Indices_equity_portfolio.rda"))
 indices_bonds_results_portfolio <- read_rds(file.path(data_location_ext, "Indices_bonds_portfolio.rda"))
 peers_equity_results_portfolio <- read_rds(file.path(data_location_ext, "Peers_equity_results_portfolio.rda"))
 peers_bonds_results_portfolio <- read_rds(file.path(data_location_ext, "Peers_bonds_results_portfolio.rda"))
 peers_equity_results_user <- read_rds(file.path(data_location_ext, "Peers_equity_results_portfolio_ind.rda"))
 peers_bonds_results_user <- read_rds(file.path(data_location_ext, "Peers_bonds_results_portfolio_ind.rda"))
-
-
-if ("scenario_source" %in% colnames(equity_results_portfolio)){equity_results_portfolio <-equity_results_portfolio %>%  filter(scenario_source %in% c("ETP2017","WEO2019"))}
-if ("scenario_source" %in% colnames(bonds_results_portfolio)){bonds_results_portfolio <-bonds_results_portfolio %>%  filter(scenario_source  %in% c("ETP2017","WEO2019"))}
-if ("scenario_source" %in% colnames(equity_results_company)){equity_results_company <-equity_results_company %>%  filter(scenario_source  %in% c("ETP2017","WEO2019"))}
-if ("scenario_source" %in% colnames(bonds_results_company)){bonds_results_company <-bonds_results_company %>%  filter(scenario_source  %in% c("ETP2017","WEO2019"))}
-
-
 
 dataframe_translations <- readr::read_csv(
   path(template_path, "data/translation/dataframe_labels.csv"),

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -37,6 +37,9 @@ real_estate_dir <- path(user_results_path, project_code, "real_estate")
 output_dir <- file.path(outputs_path, portfolio_name_ref_all)
 
 scenario <- "WEO2019_SDS"
+scenario_auto <- "ETP2017_B2DS"
+scenario_other <- "ETP2017_B2DS"
+scenario_shipping <- "SBTI_SBTI"
 portfolio_allocation_method <- "portfolio_weight"
 scenario_geography <- "Global"
 audit_file <- read_csv(file.path(proc_input_path, portfolio_name, "audit_file.csv"), col_types = cols())
@@ -247,10 +250,16 @@ js_translations <- jsonlite::fromJSON(
 shock_year <- 2030 # this should come directly from the stress test.. 2030 based on current discussions in CHPA2020 case
 pacta_sectors_not_analysed <- c("Aviation","Cement","Shipping","Steel")
 select_scenario = scenario
+select_scenario_auto = scenario_auto
+select_scenario_other = scenario_other
+select_scenario_shipping = scenario_shipping
+
 twodi_sectors = c("Power", "Automotive", "Shipping", "Oil&Gas", "Coal", "Steel", "Cement", "Aviation")
 green_techs = c("RenewablesCap", "HydroCap", "NuclearCap", "Hybrid", "Electric", "FuelCell", "Hybrid_HDV", "Electric_HDV", "FuelCell_HDV","Ac-Electric Arc Furnace","Ac-Electric Arc Furnace")
 tech_roadmap_sectors = c("Automotive", "Power", "Oil&Gas", "Coal")
 alignment_techs = c("RenewablesCap", "CoalCap", "Coal", "Oil", "Gas", "Electric", "ICE")
+
+
 repo_path = template_path
 output_dir <- file.path(outputs_path, portfolio_name_ref_all)
 
@@ -274,6 +283,9 @@ create_interactive_report(
   start_year = start_year,
   shock = shock_year,
   select_scenario = scenario,
+  select_scenario_auto = scenario_auto,
+  select_scenario_shipping = scenario_shipping,
+  select_scenario_other = scenario_other,
   portfolio_allocation_method = portfolio_allocation_method,
   scenario_geography = scenario_geography,
   twodi_sectors = c("Power", "Automotive", "Shipping", "Oil&Gas", "Coal", "Steel", "Cement", "Aviation"),

--- a/working_dir/10_Parameter_File/AnalysisParameters.yml
+++ b/working_dir/10_Parameter_File/AnalysisParameters.yml
@@ -55,6 +55,7 @@ default:
       - WEO2019
       - WEO2020
       - GECO2019
+      - SBTI
     Scenario.Geography.List:
       - Global
       - GlobalAggregate

--- a/working_dir/10_Parameter_File/AnalysisParameters.yml
+++ b/working_dir/10_Parameter_File/AnalysisParameters.yml
@@ -55,7 +55,6 @@ default:
       - WEO2019
       - WEO2020
       - GECO2019
-      - SBTI  
     Scenario.Geography.List:
       - Global
       - GlobalAggregate


### PR DESCRIPTION
This includes updates for the new scenario data as per the PR in create_interactive_report.

The aim here is to:
- update the parameter file 
- update the chosen scenario for the report
- cleaning previous approach which added the "scenario_source" column to the outputs (web_tool_script_2) and then checked and cleaned this afterwards (web_tool_script_3)

Possibly this could be changed to include more compatibility with either way of naming the scenarios, but this hasn't been implemented.

depends on 2DegreesInvesting/pacta-data/pull/6
related to 2DegreesInvesting/create_interactive_report/pull/118