### PR TITLE
Fix how sed strips whitespace

### DIFF
--- a/bin/show-upstream-and-status-at
+++ b/bin/show-upstream-and-status-at
@@ -8,5 +8,5 @@ git branch -vv | \
   # Remove leading "* " in "* <current branch> ..."
   sed s/"^* "/""/ | \
   # Replace duplicated white space with a single white space
-  sed s/"  \+"/" "/
+  sed 's/  */ /g'
 git status


### PR DESCRIPTION
this version works for me
```
sed 's/  */ /g'
```

this version does not
```
sed s/"  \+"/" "/
```

any ideas why/which is better?