### PR TITLE
Move path of logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ vignettes/*.pdf
 *.knit.md
 
 .Ruserdata
+**/working_dir/00_Log_Files/*
+!**/working_dir/00_Log_Files/.gitkeep.txt
 **/working_dir/30_Processed_Inputs/*
 !**/working_dir/30_Processed_Inputs/.gitkeep.txt
 **/working_dir/40_Results/*

--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -280,6 +280,6 @@ write_log <- function(msg, ...) {
     as.character(msg),
     ...
   )
-  write(composed, file = paste0(project_location, "/00_Log_Files/error_messages.txt"), append = TRUE)
+  write(composed, file = file.path(log_path,"error_messages.txt"), append = TRUE)
 }
 

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -43,6 +43,19 @@ create_portfolio_subfolders <- function(portfolio_name_ref_all) {
     invisible(portfolio_name_ref_all)
 }
 
+create_portfolio_subfolders_2 <- function(portfolio_name_ref_all = NULL, project_location = NULL) {
+  folders <- c("30_Processed_Inputs", "40_Results", "50_Outputs")
+
+  locs_to_create <- folders %>%
+    purrr::map(~ paste0(project_location, "/", .x, "/", portfolio_name_ref_all)) %>%
+    purrr::flatten_chr()
+
+  locs_to_create %>%
+    purrr::map(~ dir.create(.x, showWarnings = FALSE))
+
+  invisible(portfolio_name_ref_all)
+}
+
 save_if_exists <- function(df, portfolio_name_, save_name, csv_or_rds = "rds") {
   if (data_check(df)) {
     df <- df %>% filter(portfolio_name == all_of(portfolio_name_))
@@ -60,7 +73,7 @@ save_if_exists <- function(df, portfolio_name_, save_name, csv_or_rds = "rds") {
 set_webtool_paths <- function() {
   project_location <<- file.path(working_location, "working_dir")
 
-  log_path <<- file.path(project_location, "00_Log_Files")
+  log_path <<- file.path(project_location, "00_Log_Files", portfolio_name_ref_all)
   par_file_path <<- file.path(project_location, "10_Parameter_File")
   raw_input_path <<- file.path(project_location, "20_Raw_Inputs")
   proc_input_path <<- file.path(project_location, "30_Processed_Inputs")

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -47,7 +47,7 @@ create_portfolio_subfolders_2 <- function(portfolio_name_ref_all = NULL, project
   folders <- c("00_Log_Files", "30_Processed_Inputs", "40_Results", "50_Outputs")
 
   locs_to_create <- folders %>%
-    purrr::map(~ paste0(project_location, "/", .x, "/", portfolio_name_ref_all)) %>%
+    purrr::map(~ file.path(project_location, .x, portfolio_name_ref_all)) %>%
     purrr::flatten_chr()
 
   locs_to_create %>%

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -30,20 +30,7 @@ identify_portfolios <- function(portfolio_total) {
   return(port_names)
 }
 
-create_portfolio_subfolders <- function(portfolio_name_ref_all) {
-  folders <- c("30_Processed_Inputs", "40_Results", "50_Outputs")
-
-  locs_to_create <- folders %>%
-    purrr::map(~ paste0(project_location, "/", .x, "/", portfolio_name_ref_all)) %>%
-    purrr::flatten_chr()
-
-  locs_to_create %>%
-    purrr::map(~ dir.create(.x, showWarnings = FALSE))
-
-    invisible(portfolio_name_ref_all)
-}
-
-create_portfolio_subfolders_2 <- function(portfolio_name_ref_all = NULL, project_location = NULL) {
+create_portfolio_subfolders <- function(portfolio_name_ref_all = NULL, project_location = NULL) {
   folders <- c("00_Log_Files", "30_Processed_Inputs", "40_Results", "50_Outputs")
 
   locs_to_create <- folders %>%

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -44,7 +44,7 @@ create_portfolio_subfolders <- function(portfolio_name_ref_all) {
 }
 
 create_portfolio_subfolders_2 <- function(portfolio_name_ref_all = NULL, project_location = NULL) {
-  folders <- c("30_Processed_Inputs", "40_Results", "50_Outputs")
+  folders <- c("00_Log_Files", "30_Processed_Inputs", "40_Results", "50_Outputs")
 
   locs_to_create <- folders %>%
     purrr::map(~ paste0(project_location, "/", .x, "/", portfolio_name_ref_all)) %>%

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -21,6 +21,8 @@ set_global_parameters(file.path(par_file_path, "AnalysisParameters.yml"))
 # need to define an alternative location for data files
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 
+create_portfolio_subfolders_2(portfolio_name_ref_all = portfolio_name_ref_all, project_location = project_location)
+
 ######################################################################
 
 ####################
@@ -146,7 +148,6 @@ port_weights <- pw_calculations(eq_portfolio, cb_portfolio)
 # Subset and Save these files
 
 # create_portfolio_subfolders(portfolio_name_ref_all)
-create_portfolio_subfolders_2(portfolio_name_ref_all = portfolio_name_ref_all, project_location = project_location)
 
 file_names <- identify_portfolios(portfolio_total)
 

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -21,7 +21,8 @@ set_global_parameters(file.path(par_file_path, "AnalysisParameters.yml"))
 # need to define an alternative location for data files
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 
-create_portfolio_subfolders_2(portfolio_name_ref_all = portfolio_name_ref_all, project_location = project_location)
+# To save, files need to go in the portfolio specific folder, created here
+create_portfolio_subfolders(portfolio_name_ref_all = portfolio_name_ref_all, project_location = project_location)
 
 ######################################################################
 
@@ -143,11 +144,8 @@ port_weights <- pw_calculations(eq_portfolio, cb_portfolio)
 #### SAVING ####
 ################
 
-# To save, files need to go in the portfolio specific folder.
 # Identify the portfolios to save;
 # Subset and Save these files
-
-# create_portfolio_subfolders(portfolio_name_ref_all)
 
 file_names <- identify_portfolios(portfolio_total)
 

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -145,7 +145,8 @@ port_weights <- pw_calculations(eq_portfolio, cb_portfolio)
 # Identify the portfolios to save;
 # Subset and Save these files
 
-create_portfolio_subfolders(portfolio_name_ref_all)
+# create_portfolio_subfolders(portfolio_name_ref_all)
+create_portfolio_subfolders_2(portfolio_name_ref_all = portfolio_name_ref_all, project_location = project_location)
 
 file_names <- identify_portfolios(portfolio_total)
 

--- a/working_dir/00_Log_Files/.gitignore..txt
+++ b/working_dir/00_Log_Files/.gitignore..txt
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
This PR:

- adds the creation of a subfolder for "00_Log_Files" to the function `create_portfolio_subfolders()`
- `working_dir/00_Log_Files/<pf_name>/`
- moves the `create_portfolio_subfolders` function call to the initialisation section of `web_tool_script_1.R` (required to have the log folder prepared before the first calls to `write_log()`)
- surfaces an implicit function argument in `create_portfolio_subfolders()` to increase control
- changes the `log_path` in the web tool to point to the newly created subfolder (log_path is used for nothing else, so this is safe)
- changes the `write_log()` function to write the logs to a file in `log_path`
- updates `.gitignore` to cover the "00_Log_Files" directory
- adds a `.gitkeep.txt` file to "00_Log_Files"

These changes are required to be able to provide error messages to the user on a portfolio specific level.

closes: https://github.com/2DegreesInvesting/PACTA_analysis/issues/109