### PR TITLE
Surface path write log

### DIFF
--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -274,12 +274,12 @@ first_char_up <- function(x) {
 
 
 # write error log for input portfolio - msg should be a string containing the error message
-write_log <- function(msg, ...) {
+write_log <- function(msg, file_path = log_path, ...) {
   composed <- paste(
     as.character(Sys.time()),
     as.character(msg),
     ...
   )
-  write(composed, file = file.path(log_path,"error_messages.txt"), append = TRUE)
+  write(composed, file = file.path(file_path,"error_messages.txt"), append = TRUE)
 }
 

--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -63,35 +63,40 @@ clean_portfolio_col_types <- function(portfolio, grouping_variables) {
       "Wrong variable class for investor_name. Should be character, but is ",
       class(portfolio$investor_name),
       ". This can introduce errors in further calculations!"
-    ))
+    ),
+    file_path = log_path)
   }
   if (is.character(portfolio$portfolio_name) == FALSE) {
     write_log(msg = paste0(
       "Wrong variable class for portfolio_name Should be character, but is ",
       class(portfolio$portfolio_name),
       ". This can introduce errors in further calculations!"
-    ))
+    ),
+    file_path = log_path)
   }
   if (is.numeric(portfolio$market_value) == FALSE) {
     write_log(msg = paste0(
       "Wrong variable class for market_value Should be numeric, but is ",
       class(portfolio$market_value),
       ". This can introduce errors in further calculations!"
-    ))
+    ),
+    file_path = log_path)
   }
   if (is.character(portfolio$currency) == FALSE) {
     write_log(msg = paste0(
       "Wrong variable class for currency Should be character, but is ",
       class(portfolio$currency),
       ". This can introduce errors in further calculations!"
-    ))
+    ),
+    file_path = log_path)
   }
   if (is.character(portfolio$isin) == FALSE) {
     write_log(msg = paste0(
       "Wrong variable class for isin Should be character, but is ",
       class(portfolio$isin),
       ". This can introduce errors in further calculations!"
-    ))
+    ),
+    file_path = log_path)
   }
   ### what about number_of_shares???
 
@@ -112,7 +117,8 @@ clear_portfolio_input_blanks <- function(portfolio) {
               because of missing values in at least one of the variables", str_c(grouping_variables, collapse = ", "),
       "\n To ensure complete analysis, please upload a file without
                           missing values in these columns."
-    ))
+    ),
+    file_path = log_path)
 
     portfolio <- portfolio %>% filter_at(
       grouping_variables, all_vars(!is.na(.))
@@ -191,7 +197,10 @@ check_missing_cols <- function(portfolio, grouping_variables) {
   missing_columns <- setdiff(required_input_cols, colnames(portfolio))
 
   if (length(missing_columns) > 0) {
-    write_log(msg = paste0("The input file is missing the following data columns: ", missing_columns))
+    write_log(
+      msg = paste0("The input file is missing the following data columns: ", missing_columns),
+      file_path = log_path
+      )
     stop(paste0("The input file is missing the following data columns: ", missing_columns))
   }
 

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -23,7 +23,10 @@ identify_portfolios <- function(portfolio_total) {
 
 
   if (length(port_names %>% select(investor_name) %>% distinct()) > 1) {
-    write_log("There is more than one investor name within a portfolio. Please correct the input data and retry.")
+    write_log(
+      msg = "There is more than one investor name within a portfolio. Please correct the input data and retry.",
+      file_path = log_path
+    )
     stop("More than one investor in portfolio")
   }
 
@@ -117,18 +120,27 @@ get_input_files <- function(portfolio_name_ref_all) {
 
   input_file_type <- unique(tools::file_ext(grep(portfolio_name_ref_all, list.files(path = input_path, full.names = F), value = T)))
   if (!input_file_type %in% c("csv", "xlsx", "txt")) {
-    write_log(msg = "Input file format not supported. Must be .csv, .xlsx or .txt")
+    write_log(
+      msg = "Input file format not supported. Must be .csv, .xlsx or .txt",
+      file_path = log_path
+      )
     stop("Input file format not supported. Must be .csv, .xlsx or .txt")
   }
 
 
   if (!all(portfolio_name_ref_all %in% input_names)) {
-    write_log(msg = "Difference in input files and input argument portfolio names.")
+    write_log(
+      msg = "Difference in input files and input argument portfolio names.",
+      file_path = log_path
+      )
     stop("Difference in input files and input argument portfolio names.")
   }
 
   if (any(!portfolio_name_ref_all %in% input_names)) {
-    write_log(msg = "Missing input argument")
+    write_log(
+      msg = "Missing input argument",
+      file_path = log_path
+      )
     stop("Missing input argument")
   }
 
@@ -137,11 +149,17 @@ get_input_files <- function(portfolio_name_ref_all) {
   portfolio_file_names <- gsub("_PortfolioParameters.yml", "", portfolio_file_names)
 
   if (!all(portfolio_name_ref_all %in% portfolio_file_names)) {
-    write_log(msg = "Difference in parameter files and input argument portfolio names.")
+    write_log(
+      msg = "Difference in parameter files and input argument portfolio names.",
+      file_path = log_path
+      )
     stop("Difference in parameter files and input argument portfolio names.")
   }
   if (any(!portfolio_name_ref_all %in% portfolio_file_names)) {
-    write_log(msg = "Missing portfolio parameter file")
+    write_log(
+      msg = "Missing portfolio parameter file",
+      file_path = log_path
+      )
     stop("Missing portfolio parameter file")
   }
   # this is already tested above -- duplicate
@@ -178,7 +196,10 @@ get_input_files <- function(portfolio_name_ref_all) {
   portfolio <- clear_portfolio_input_blanks(portfolio)
 
   if (portfolio %>% pull(investor_name) %>% unique() %>% length() > 1) {
-    write_log(msg = "Multiple investors detected. Only one investor at a time can be anaylsed")
+    write_log(
+      msg = "Multiple investors detected. Only one investor at a time can be anaylsed",
+      file_path = log_path
+      )
     stop("Multiple investors detected. Only one investor at a time can be anaylsed")
   }
 
@@ -210,9 +231,14 @@ read_web_input_file <- function(input_file_path) {
   if (data_check(input_file) == FALSE) {
     warning("Input file not readable")
     ifelse(nrow(input_file) == 0,
-      write_log(msg = "Input file has 0 rows. Please ensure the uploaded file is not empty."),
-      write_log(msg = "Input file could not be transformed into a data.frame.
-                     Please check the uploaded file has the correct format.")
+      write_log(
+        msg = "Input file has 0 rows. Please ensure the uploaded file is not empty.",
+        file_path = log_path
+        ),
+      write_log(
+        msg = "Input file could not be transformed into a data.frame. Please check the uploaded file has the correct format.",
+        file_path = log_path
+      )
     )
   }
 


### PR DESCRIPTION
Following up on:

https://github.com/2DegreesInvesting/PACTA_analysis/pull/283

This PR:

- surfaces the file path in `write_log` as the argument `file_path` with default `log_path`, so it does not depend on `log_path` being given via the global environment
- changes all function calls of `write_log` to include the named argument `file_path`

closes: https://github.com/2DegreesInvesting/PACTA_analysis/issues/286
