### PR TITLE
Setup environment to test-r-scripts

### DIFF
--- a/.github/workflows/test-r-scripts.yaml
+++ b/.github/workflows/test-r-scripts.yaml
@@ -23,32 +23,32 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-
-      - uses: r-lib/actions/setup-pandoc@master
-      - uses: r-lib/actions/setup-tinytex@v1
-
       - name: Checkout PACTA_analysis
         uses: actions/checkout@v2
         with:
           path: PACTA_analysis
+
       - name: Checkout pacta-data
         uses: actions/checkout@v2
         with:
           repository: 2DegreesInvesting/pacta-data
           token: ${{ secrets.MAURO_PAT_FOR_2DII }}
           path: pacta-data
+
       - name: Checkout create_interactive_report
         uses: actions/checkout@v2
         with:
           repository: 2DegreesInvesting/create_interactive_report
           token: ${{ secrets.MAURO_PAT_FOR_2DII }}
           path: create_interactive_report
+
       - name: Checkout StressTestingModelDev
         uses: actions/checkout@v2
         with:
           repository: 2DegreesInvesting/StressTestingModelDev
           token: ${{ secrets.MAURO_PAT_FOR_2DII }}
           path: StressTestingModelDev
+
       - name: Checkout user_results
         uses: actions/checkout@v2
         with:
@@ -56,6 +56,8 @@ jobs:
           token: ${{ secrets.MAURO_PAT_FOR_2DII }}
           path: user_results
 
+      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-tinytex@v1
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}

--- a/.github/workflows/test-r-scripts.yaml
+++ b/.github/workflows/test-r-scripts.yaml
@@ -23,6 +23,10 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+
+      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-tinytex@v1
+
       - name: Checkout PACTA_analysis
         uses: actions/checkout@v2
         with:
@@ -59,6 +63,8 @@ jobs:
 
       - name: Install dependencies from CRAN
         run: |
+          install.packages("rmarkdown")
+          install.packages("knitr")
           install.packages("renv")
           dependencies <- renv::dependencies()$Package
           install.packages(dependencies)


### PR DESCRIPTION
Closes #285
Replaces #291 #292 and #293 combined.All three PRs touched the
same file and are related in that together they create the
environment for test-r-scripts. This combined PR makes it
easier to review the relationship between all changes, and
avoids merge conflicts. All in all, I expect the reiew to
go more smoothly.