### PR TITLE
run-web-tool now shows who and when commited last

### DIFF
--- a/bin/show-upstream-and-status-at
+++ b/bin/show-upstream-and-status-at
@@ -3,9 +3,7 @@
 cd $1
 echo $(basename $(pwd))
 current_branch=$(git rev-parse --abbrev-ref HEAD)
-
 git fetch --quiet
-
 echo "$(git log --pretty='%an commited %cr:' | head -1)"
 git branch -vv | \
   grep " $current_branch " | \

--- a/bin/show-upstream-and-status-at
+++ b/bin/show-upstream-and-status-at
@@ -3,7 +3,10 @@
 cd $1
 echo $(basename $(pwd))
 current_branch=$(git rev-parse --abbrev-ref HEAD)
+
 git fetch --quiet
+
+echo "$(git log --pretty='%an commited %cr:' | head -1)"
 git branch -vv | \
   grep " $current_branch " | \
   # Remove leading "* " in "* <current branch> ..."


### PR DESCRIPTION
It's often useful to know who authored the latest commit and when. This PR adds such information:


```bash
➜  PACTA_analysis git:(who-commited-when) ./bin/show-upstream-and-status-at ../PACTA_analysis
PACTA_analysis
Mauro Lepore commited 31 seconds ago:
who-commited-when b5fe4c5 [origin/who-commited-when] Show who commited when
On branch who-commited-when
Your branch is up to date with 'origin/who-commited-when'.

nothing to commit, working tree clean

```