### PR TITLE
removed reference to old translation file

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -239,10 +239,6 @@ peers_bonds_results_portfolio <- read_rds(file.path(data_location_ext, "Peers_bo
 peers_equity_results_user <- read_rds(file.path(data_location_ext, "Peers_equity_results_portfolio_ind.rda"))
 peers_bonds_results_user <- read_rds(file.path(data_location_ext, "Peers_bonds_results_portfolio_ind.rda"))
 
-dataframe_translations <- readr::read_csv(
-  path(template_path, "data/translation/dataframe_labels.csv"),
-  col_types = cols()
-  )
 js_translations <- jsonlite::fromJSON(
   txt = path(template_path, "data/translation/js_labels.json")
 )
@@ -309,7 +305,6 @@ create_interactive_report(
   peers_bonds_results_user = peers_bonds_results_user,
   equity_results_stress_test = equity_results_stress_test,
   bonds_results_stress_test = bonds_results_stress_test,
-  dataframe_translations = dataframe_translations,
   js_translations = js_translations,
   ipr_results_stress_test = ipr_results_stress_test,
   display_currency = "CHF",


### PR DESCRIPTION
This dataframe has been replaced with @jdhoffa's newer translation method and can be deleted. 

This PR removes the reading the of the file and the reference in the create_interactive_report function.