### PR TITLE
fs "equivalents" are not always equivalent

### DIFF
--- a/test_test_cases.R
+++ b/test_test_cases.R
@@ -9,7 +9,7 @@ test_cases_csvs <- fs::dir_ls(test_cases_dir, regexp = "[.]csv")
 
 test_cases_output_dir <- "test_cases"
 
-fs::dir_delete(test_cases_output_dir)
+try(fs::dir_delete(test_cases_output_dir))
 
 for (i in seq_along(test_cases_csvs)) {
   filepath <- test_cases_csvs[[i]]


### PR DESCRIPTION
`fs::dir_delete` always errors out if it can't find the directory whereas `unlink` does not, so in order to use the `fs` "equivalent" of the base function here, it will have to be wrapped in a `try` since the intended expectation is that the directory may or may not be there