### PR TITLE
remove obsolete/hazardous filter on eq portfolio

### DIFF
--- a/3_run_analysis.R
+++ b/3_run_analysis.R
@@ -34,8 +34,6 @@ if (file.exists(equity_input_file)) {
 
     port_eq <- calculate_weights(port_raw_eq, "Equity", grouping_variables)
 
-    port_eq <- port_eq %>% filter(port_weight > 1e-6)
-
     port_eq <- merge_in_ald(port_eq, ald_scen_eq)
 
     # Portfolio weight methodology


### PR DESCRIPTION
This PR:

- removes the filter on the equity part of the portfolio that removes holdings with a very small weight
- this was originally a hack to get rid of duplicates but is long superseded by explicitly handling duplicates in a dedicated list of duplicate ISINs
- in rare cases, this filter can erroneously remove valid equity holdings, so it should be removed
- this change does not touch pacta 2020 in any way, as the filter was only set in the offline version

closes: https://github.com/2DegreesInvesting/PACTA_analysis/issues/309