### PR TITLE
change na to 0

### DIFF
--- a/0_portfolio_test.R
+++ b/0_portfolio_test.R
@@ -167,6 +167,8 @@ aggregate_portfolio <- function(df) {
         plan_tech_prod, plan_alloc_wt_tech_prod, plan_carsten, plan_emission_factor,
         scen_tech_prod, scen_alloc_wt_tech_prod, scen_carsten, scen_emission_factor
       ) %>%
+      mutate(plan_emission_factor = ifelse(is.na(plan_emission_factor), 0, plan_emission_factor),
+             scen_emission_factor = ifelse(is.na(scen_emission_factor), 0, scen_emission_factor)) %>%
       group_by(
         !!!rlang::syms(grouping_variables), scenario, allocation,
         equity_market, scenario_geography, year,


### PR DESCRIPTION
This deals with an issue that arises when the plan_emission_factor is NA and the scen_emission_factor == 0. This is aggregated to scenario level where it then sums to 0 because na.rm == T. When this is summed, the NA is ignored, where as the 0 is used in a weighted averaged. And the plan and scenario values differ for year == start_year which is not the accurate case. 

This resolves that issue. Could be solved somewhere earlier however, this is a reasonable solution. If the scenario emission factor is 0 then the plan emission factor can also be 0. 