### PR TITLE
Assert input to green_brown() has length 1

### DIFF
--- a/0_graphing_functions.R
+++ b/0_graphing_functions.R
@@ -757,9 +757,11 @@ graph_name <- function(plotnumber, ParameterFile, explicit_filename = "") {
   return(graphname)
 }
 
+# FIXME: There is another green_brown() in the repo create_interactive_report and
+# they are not identical. Which one should win?
 green_brown <- function(Tech) {
   GreenTechs <- c("Electric", "Hybrid", "RenewablesCap", "HydroCap", "NuclearCap")
-
+  stopifnot(length(Tech) == 1L)
   if (Tech %in% GreenTechs) {
     TechIs <- "green"
   } else {


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/create_interactive_report/pull/177

This seems not urgent. 

I see two functions with the name `green_brown()` -- one here and the other one in create_interactive_report -- and they are not identical. The version in create_interactive_report seems more developed but I can't tell which version should win. Right now the web tool seems to be using the version from create_interactive_report.

Just in case the version here gets called somewhere, I added an assertion to detect the problem that https://github.com/2DegreesInvesting/create_interactive_report/pull/177 fixed.