### PR TITLE
Improve emissions data

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1311,14 +1311,14 @@ calculate_average_portfolio_emissions <- function(portfolio_total,
     left_join(
       select(comp_fin_data, company_id, bics_sector),
       by = "company_id"
-      ) %>%
+    ) %>%
     group_by(
       investor_name,
       portfolio_name,
       asset_type,
       financial_sector,
       bics_sector
-      ) %>%
+    ) %>%
     summarise(value_usd = sum(value_usd, na.rm = T),  .groups = "drop") %>%
     left_join(
       select(
@@ -1327,9 +1327,9 @@ calculate_average_portfolio_emissions <- function(portfolio_total,
         asset_type,
         median_intensity,
         mean_intensity
-        ),
+      ),
       by = c("bics_sector", "asset_type")
-      )
+    )
 
   # Create averages where bics sectors were missing
   average_other_sectors <- min_portfolio %>%
@@ -1337,20 +1337,20 @@ calculate_average_portfolio_emissions <- function(portfolio_total,
     summarise(
       mean_intensity = mean(mean_intensity, na.rm = T),
       .groups = "drop"
-      )
+    )
 
   min_portfolio <- min_portfolio %>%
     left_join(
       average_other_sectors,
       by = c("asset_type", "financial_sector")
-      ) %>%
+    ) %>%
     mutate(
       mean_intensity = ifelse(
         is.na(mean_intensity.x),
         mean_intensity.y,
         mean_intensity.x
-        )
-      ) %>%
+      )
+    ) %>%
     select(-mean_intensity.x, -mean_intensity.y)  %>%
     mutate(weighted_sector_emissions = value_usd * mean_intensity)
 
@@ -1360,18 +1360,18 @@ calculate_average_portfolio_emissions <- function(portfolio_total,
         financial_sector != "Other",
         financial_sector,
         bics_sector
-        ),
+      ),
       sector = ifelse(
         is.na(sector),
         "Other",
         sector
-        )
-      ) %>%
+      )
+    ) %>%
     group_by(investor_name, portfolio_name, asset_type,sector) %>%
     summarise(
       weighted_sector_emissions = sum(weighted_sector_emissions, na.rm = T),
       .groups = "drop"
-      )
+    )
 
 
 

--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1293,6 +1293,42 @@ clean_unmatched_holdings <- function(portfolio) {
 }
 
 ### Emissions work
+calculate_average_portfolio_emissions <- function(
+  portfolio_total,
+  comp_fin_data,
+  average_sector_intensity){
+
+  min_portfolio <- portfolio_total %>%
+    select(investor_name, portfolio_name, financial_sector, security_mapped_sector,  company_id, value_usd, asset_type) %>%
+    filter(asset_type %in% c("Equity", "Bonds")) %>%
+    left_join(comp_fin_data %>% select(company_id, bics_sector), by = "company_id") %>%
+    group_by(investor_name, portfolio_name,asset_type, financial_sector, bics_sector) %>%
+    summarise(value_usd = sum(value_usd, na.rm = T),  .groups = "drop") %>%
+    left_join(average_sector_intensity %>% select(bics_sector, asset_type, median_intensity, mean_intensity), by = c("bics_sector", "asset_type"))
+
+  # Create averages where bics sectors were missing
+  average_other_sectors <- min_portfolio %>%
+    group_by(asset_type, financial_sector) %>%
+    summarise(mean_intensity = mean(mean_intensity, na.rm = T),  .groups = "drop")
+
+  min_portfolio <- min_portfolio %>%
+    left_join(average_other_sectors, by = c("asset_type", "financial_sector")) %>%
+    mutate(mean_intensity = ifelse(is.na(mean_intensity.x), mean_intensity.y, mean_intensity.x)) %>%
+    select(-mean_intensity.x, -mean_intensity.y)  %>%
+    mutate(weighted_sector_emissions = value_usd * mean_intensity)
+
+  min_portfolio <- min_portfolio %>%
+    mutate(sector = ifelse(financial_sector != "Other", financial_sector, bics_sector),
+           sector = ifelse(is.na(sector), "Other", sector)) %>%
+    group_by(investor_name, portfolio_name, asset_type,sector) %>%
+    summarise(weighted_sector_emissions = sum(weighted_sector_emissions, na.rm = T),  .groups = "drop")
+
+
+
+  return(min_portfolio)
+}
+
+
 
 get_average_emission_data <- function(inc_emission_factors) {
   average_sector_intensity <- data.frame()

--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1293,35 +1293,85 @@ clean_unmatched_holdings <- function(portfolio) {
 }
 
 ### Emissions work
-calculate_average_portfolio_emissions <- function(
-  portfolio_total,
-  comp_fin_data,
-  average_sector_intensity){
+calculate_average_portfolio_emissions <- function(portfolio_total,
+                                                  comp_fin_data,
+                                                  average_sector_intensity) {
 
   min_portfolio <- portfolio_total %>%
-    select(investor_name, portfolio_name, financial_sector, security_mapped_sector,  company_id, value_usd, asset_type) %>%
+    select(
+      investor_name,
+      portfolio_name,
+      financial_sector,
+      security_mapped_sector,
+      company_id,
+      value_usd,
+      asset_type
+    ) %>%
     filter(asset_type %in% c("Equity", "Bonds")) %>%
-    left_join(comp_fin_data %>% select(company_id, bics_sector), by = "company_id") %>%
-    group_by(investor_name, portfolio_name,asset_type, financial_sector, bics_sector) %>%
+    left_join(
+      select(comp_fin_data, company_id, bics_sector),
+      by = "company_id"
+      ) %>%
+    group_by(
+      investor_name,
+      portfolio_name,
+      asset_type,
+      financial_sector,
+      bics_sector
+      ) %>%
     summarise(value_usd = sum(value_usd, na.rm = T),  .groups = "drop") %>%
-    left_join(average_sector_intensity %>% select(bics_sector, asset_type, median_intensity, mean_intensity), by = c("bics_sector", "asset_type"))
+    left_join(
+      select(
+        average_sector_intensity,
+        bics_sector,
+        asset_type,
+        median_intensity,
+        mean_intensity
+        ),
+      by = c("bics_sector", "asset_type")
+      )
 
   # Create averages where bics sectors were missing
   average_other_sectors <- min_portfolio %>%
     group_by(asset_type, financial_sector) %>%
-    summarise(mean_intensity = mean(mean_intensity, na.rm = T),  .groups = "drop")
+    summarise(
+      mean_intensity = mean(mean_intensity, na.rm = T),
+      .groups = "drop"
+      )
 
   min_portfolio <- min_portfolio %>%
-    left_join(average_other_sectors, by = c("asset_type", "financial_sector")) %>%
-    mutate(mean_intensity = ifelse(is.na(mean_intensity.x), mean_intensity.y, mean_intensity.x)) %>%
+    left_join(
+      average_other_sectors,
+      by = c("asset_type", "financial_sector")
+      ) %>%
+    mutate(
+      mean_intensity = ifelse(
+        is.na(mean_intensity.x),
+        mean_intensity.y,
+        mean_intensity.x
+        )
+      ) %>%
     select(-mean_intensity.x, -mean_intensity.y)  %>%
     mutate(weighted_sector_emissions = value_usd * mean_intensity)
 
   min_portfolio <- min_portfolio %>%
-    mutate(sector = ifelse(financial_sector != "Other", financial_sector, bics_sector),
-           sector = ifelse(is.na(sector), "Other", sector)) %>%
+    mutate(
+      sector = ifelse(
+        financial_sector != "Other",
+        financial_sector,
+        bics_sector
+        ),
+      sector = ifelse(
+        is.na(sector),
+        "Other",
+        sector
+        )
+      ) %>%
     group_by(investor_name, portfolio_name, asset_type,sector) %>%
-    summarise(weighted_sector_emissions = sum(weighted_sector_emissions, na.rm = T),  .groups = "drop")
+    summarise(
+      weighted_sector_emissions = sum(weighted_sector_emissions, na.rm = T),
+      .groups = "drop"
+      )
 
 
 

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -131,14 +131,10 @@ identify_missing_data(portfolio_total)
 
 audit_file <- create_audit_file(portfolio_total)
 
-emissions_totals <- calculate_portfolio_emissions(
-  inc_emission_factors,
-  audit_file,
-  fin_data,
+emissions_totals <- calculate_average_portfolio_emissions(
+  portfolio_total,
   comp_fin_data,
-  average_sector_intensity,
-  company_emissions
-)
+  average_sector_intensity)
 
 port_weights <- pw_calculations(eq_portfolio, cb_portfolio)
 


### PR DESCRIPTION
This changes the way of calculating the emissions data, ignoring 2dii values and rather using the average values we have available. 

This function
- merges in the emissions factors based on the company bics_sector
- where this is in the financial sector of a pact sector, this is identified
- where there is missing bics_sector info, but there is pacta sector, a mean sector value is applied
- the mean value is used to calculate an average financed emissions

This is late for this change - but the data is now just being used with a different priority given the quality of the emissions factors at aggregate were not sufficient. 