### PR TITLE
enable running as non-user when doing latex

### DIFF
--- a/bin/run-r-scripts
+++ b/bin/run-r-scripts
@@ -5,11 +5,6 @@ umask 000
 
 cd /bound
 
-# Install faster, using binaries for linux from RStudio package manager
-echo 'options(repos = c(CRAN = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest"))' >> ~/.Rprofile
-echo 'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))' >> ~/.Rprofile
-# Rscript -e "update.packages(ask = FALSE)"
-Rscript -e 'pkgs_to_install <- c("assertthat", "bookdown", "config", "conflicted", "countrycode", "data.table", "devtools", "dplyr", "forcats", "fs", "fst", "ggplot2", "glue", "here", "highcharter", "janitor", "jsonlite", "knitr", "purrr", "readr", "readxl", "renv", "reshape2", "rlang", "rmarkdown", "rstudioapi", "scales", "stringr", "testthat", "tibble", "tidyr", "tidyselect", "usethis", "withr", "writexl", "zoo"); install.packages(setdiff(pkgs_to_install, installed.packages()))'
 Rscript --vanilla web_tool_script_1.R "${1:-TestPortfolio_Input}" \
   && Rscript --vanilla web_tool_script_2.R "${1:-TestPortfolio_Input}" \
-  && Rscript --vanilla web_tool_script_3.R "${1:-TestPortfolio_Input}"
+  && Rscript --no-save --no-restore --no-site-file --no-environ web_tool_script_3.R "${1:-TestPortfolio_Input}"


### PR DESCRIPTION
this is required so that when the docker is run with this mysterious non-user 1000 it can still load its .Rprofile and get the right settings to enable rendering through latex