### PR TITLE
New file .pacta helps locates pacta repos

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -47,3 +47,4 @@
 ^bin$
 ^docker$
 ^\.renvignore$
+^\.pacta$


### PR DESCRIPTION
Inspired by the package 'here', this PR helps define membership to the pacta ecosystem via a root file '.pacta' -- discoverable with 'locate' (and our new wrapper [`pacta-find`](https://github.com/2DegreesInvesting/pacta-cli/blob/master/pacta-find)). 

<img src=http://i.imgur.com/t5S4Ex5.png width=600>

This aliviates the problem of having not just one but an ecosystem of related packages, because we can now discover automatically where in a system the members live -- regarless of their name. This is fundamental to building tools that work on all repositories at once (command-line applications, R functions, docker images).