### PR TITLE
Add *test_cases* to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -47,3 +47,5 @@
 ^bin$
 ^docker$
 ^\.renvignore$
+^test_cases$
+^test_test_cases\.R$


### PR DESCRIPTION
This PR fixes a NOTE in R CMD check.