### PR TITLE
Fix original scripts

### DIFF
--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -82,10 +82,10 @@ set_global_parameters <- function(file_path) {
 
   equity_market_list <<- cfg$Lists$Equity.Market.List
 
-  allowable_asset_list <<- cfg$Lists$AssetTypes
-  if (is.null(allowable_asset_list)) {
-    allowable_asset_list <<- c("Funds", "Equity", "Bonds", "Others")
-  }
+  # allowable_asset_list <<- cfg$Lists$AssetTypes
+  # if (is.null(allowable_asset_list)) {
+  #   allowable_asset_list <<- c("Funds", "Equity", "Bonds", "Others")
+  # }
   # allowable_asset_list <<- allowable_asset_list
 
   global_aggregate_sector_list <<- cfg$Lists$Global.Aggregate.Sector.List

--- a/1_portfolio_check_initialisation.R
+++ b/1_portfolio_check_initialisation.R
@@ -1,14 +1,9 @@
 ## Project Initialisation
-rm(list = ls())
-
-options(encoding = "UTF-8")
-
 devtools::load_all()
 use_r_packages()
+library(r2dii.utils)
 
 ## Project Initialisation
-rm(list = ls())
-
 if (rstudioapi::isAvailable()) {
   working_location <- dirname(rstudioapi::getActiveDocumentContext()$path)
 } else {


### PR DESCRIPTION
This PR makes changes to the original scripts to ensure that these can be run for offline projects. 

There is an open question as to whether we switch to allow the html reports also to be created, or whether we stick with the pdfs. For this PR I suggest we stick with PDF. 

@jacobvjk I've got some open questions as to changes in the fin data and sector classifications and whether we can easily incorporate the stress testing or not. 
