### PR TITLE
add na.rm to port weight calc

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1658,7 +1658,7 @@ pw_calculations <- function(eq_portfolio, cb_portfolio){
 
   pw <- port_all %>%
     group_by(!!!rlang::syms(grouping_variables), company_id) %>%
-    summarise(port_weight = sum(port_weight), .groups = "drop") %>%
+    summarise(port_weight = sum(port_weight, na.rm = T), .groups = "drop") %>%
     select(company_id, port_weight) %>%
     rename(portfolio_weight = port_weight)
 


### PR DESCRIPTION
Noticed a missing na.rm on the calculation of the port weight for the CAG. This should fix errors if nas come through the data. 