### PR TITLE
New function to skip check() but run test()

### DIFF
--- a/tests/testthat/helper-skip_check_but_run_test.R
+++ b/tests/testthat/helper-skip_check_but_run_test.R
@@ -1,0 +1,6 @@
+skip_check_but_run_test <- function() {
+  testthat::skip_if_not(
+    fs::file_exists(here::here(".pacta")),
+    "Source code is unavailable"
+  )
+}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -15,3 +15,14 @@ test_that("use_r_packages() puts listed packages on search() path", {
     expect_true(is_attached(package))
   }
 })
+
+test_that("helper skip_check_but_run_test() works as expected", {
+  # This test should not be skipped during devtools::test()
+  # This test should be skipped during devtools::check()
+  # If you remove `skip_check_but_run_test()`, devtools::check() should error
+  skip_check_but_run_test()
+
+  # This file should be available only when the source code is accessible, i.e.
+  # not during R CMD check, when the code runs from the system installation
+  expect_true(fs::file_exists(here::here(".pacta")))
+})


### PR DESCRIPTION
https://github.com/2DegreesInvesting/PACTA_analysis/pull/340#discussion_r529172294 wasn't exactly right. My experiments suggest that we can use `here::here()` to reach the source only during `devtools::test()` but not during `devtools::check()`. Here I add a new test helper to skip `check()` but run `test()`; while it's not ideal to skip `check()`, being able to at least test seems useful.
