### PR TITLE
Test test_r_scripts: example data exists

### DIFF
--- a/R/path_from.R
+++ b/R/path_from.R
@@ -1,0 +1,12 @@
+path_from <- function(from = NULL, ...) {
+  if (is.null(from)) return(here::here(...))
+  here::here(from, ...)
+}
+
+raw_inputs <- function() {
+  list("working_dir", "20_Raw_Inputs")
+}
+
+parameter_file <- function() {
+  list("working_dir", "10_Parameter_File")
+}

--- a/tests/testthat/test-path_from.R
+++ b/tests/testthat/test-path_from.R
@@ -1,0 +1,11 @@
+test_that("is sensitive to `from`", {
+  expect_equal(
+    path_from("a", "b", "c"),
+    here::here("a", "b", "c")
+  )
+
+  expect_equal(
+    path_from(),
+    here::here()
+  )
+})

--- a/tests/testthat/test-test_r_scripts.R
+++ b/tests/testthat/test-test_r_scripts.R
@@ -4,3 +4,14 @@ test_that("stop_on_error stops on error", {
   expect_error(stop_on_error(exit_code = 1), "error")
   expect_error(stop_on_error(exit_code = 99), "error")
 })
+
+test_that("example data is available under working_dir/", {
+  # https://git.io/JkX5O
+  config <-
+    path_from(parameter_file(), "TestPortfolio_Input_PortfolioParameters.yml")
+  portfolio_name <- get_param("parameters", "portfolio_name_in")(config)
+
+  example_data <- path_from(raw_inputs(), glue::glue("{portfolio_name}.csv"))
+  expect_true(fs::file_exists(example_data))
+})
+


### PR DESCRIPTION
This PR tests that the expected input data exists. The test
is quite abstract because I tried to avoid writing the
actual path to the file and instead get it via an interface.
My intent is to have a single place where to update the
path when it changes. Right now the value is unclear because
the path is used only once, but I it would pay off if we
do reuse the interface in a few places. I should probabbly
follow up with a PR replacing hard-coded paths with calls
to this interface.﻿
