### PR TITLE
make function arg explicit

### DIFF
--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -251,11 +251,14 @@ check_input_file_contents <- function(portfolio_, portfolio_name, investor_name)
   if (length(setdiff(necessary_columns, colnames(portfolio_clean))) > 0) {
     missing_cols <- setdiff(necessary_columns, colnames(portfolio_clean))
 
-    write_log(msg = paste(
-      "The uploaded portfolio file contains the following missing variables:", str_c(missing_cols, collapse = ", "),
-      "\n For correct analysis, please ensure the following required variables are included in your uploaded portfolio file:",
-      str_c(necessary_columns, collapse = ", ")
-    ))
+    write_log(
+      msg = paste(
+        "The uploaded portfolio file contains the following missing variables:", str_c(missing_cols, collapse = ", "),
+        "\n For correct analysis, please ensure the following required variables are included in your uploaded portfolio file:",
+        str_c(necessary_columns, collapse = ", ")
+      ),
+      file_path = log_path
+    )
     stop(paste0("Missing inputs for this portfolio: ", str_c(missing_cols, collapse = ", ")))
   }
 


### PR DESCRIPTION
closes https://github.com/2DegreesInvesting/PACTA_analysis/issues/353

This PR:

- adds the named argument to the function call write_log() in one instance where the explicit argument was missing
- does not touch the functionality of the code, as the default value is the same as the argument that is now being explicitly passed
- makes the code a bit more robust to future changes