### PR TITLE
add st price data config on proj level

### DIFF
--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -78,6 +78,7 @@ set_project_parameters <- function(file_path){
   alignment_techs <<- cfg$sectors$alignment_techs
 
   shock_year <<- cfg$stress_test$shock_year
+  price_data_version <<- cfg$stress_test$price_data_version
 
 
   # meta_investor_name <<- cfg$ComparisonBenchmarks$MetaInvestorName

--- a/parameter_files/ProjectParameters_CHPA2020.yml
+++ b/parameter_files/ProjectParameters_CHPA2020.yml
@@ -4,8 +4,8 @@ default:
         project_report_name: swiss
         display_currency: CHF
         currency_exchange_value: 1.03
-         
-    parameters: 
+
+    parameters:
         timestamp: 2019Q4
         dataprep_timestamp: 2019Q4_250220
         start_year: 2020
@@ -24,7 +24,7 @@ default:
         has_credit: FALSE
         inc_emissionfactors: TRUE
         inc_stresstest: TRUE
-    
+
     sectors:
         tech_roadmap_sectors:
             - Power
@@ -56,35 +56,36 @@ default:
             - Gas
             - Electric
             - ICE
-            
+
     asset_types:
         - Equity
         - Bonds
         - Others
         - Funds
-        
+
     scenario_sources_list:
         - ETP2017
         - WEO2019
         - WEO2020
         - GECO2019
-      
+
     scenario_geography_list:
         - Global
         - GlobalAggregate
         - NonOECD
         - OECD
-      
+
     equity_market_list:
         - GlobalMarket
         - DevelopedMarket
         - EmergingMarket
-      
-    grouping_variables: 
+
+    grouping_variables:
         - investor_name
-        - portfolio_name  
-        
+        - portfolio_name
+
     stress_test:
         shock_year: 2030
-        
-    
+        price_data_version: 2020Q4
+
+

--- a/parameter_files/ProjectParameters_GENERAL.yml
+++ b/parameter_files/ProjectParameters_GENERAL.yml
@@ -4,8 +4,8 @@ default:
         project_report_name: general
         display_currency: USD
         currency_exchange_value: 1
-         
-    parameters: 
+
+    parameters:
         timestamp: 2019Q4
         dataprep_timestamp: 2019Q4_250220
         start_year: 2020
@@ -24,7 +24,7 @@ default:
         has_credit: FALSE
         inc_emissionfactors: TRUE
         inc_stresstest: TRUE
-    
+
     sectors:
         tech_roadmap_sectors:
             - Power
@@ -56,35 +56,35 @@ default:
             - Gas
             - Electric
             - ICE
-            
+
     asset_types:
         - Equity
         - Bonds
         - Others
         - Funds
-        
+
     scenario_sources_list:
         - ETP2017
         - WEO2019
         - WEO2020
         - GECO2019
-      
+
     scenario_geography_list:
         - Global
         - GlobalAggregate
         - NonOECD
         - OECD
-      
+
     equity_market_list:
         - GlobalMarket
         - DevelopedMarket
         - EmergingMarket
-      
-    grouping_variables: 
+
+    grouping_variables:
         - investor_name
-        - portfolio_name  
-        
+        - portfolio_name
+
     stress_test:
         shock_year: 2030
-        
-    
+        price_data_version: 2021Q1
+

--- a/parameter_files/ProjectParameters_PA2020FL.yml
+++ b/parameter_files/ProjectParameters_PA2020FL.yml
@@ -4,8 +4,8 @@ default:
         project_report_name: liechtenstein
         display_currency: CHF
         currency_exchange_value: 1.03
-         
-    parameters: 
+
+    parameters:
         timestamp: 2019Q4
         dataprep_timestamp: 2019Q4_250220
         start_year: 2020
@@ -24,7 +24,7 @@ default:
         has_credit: FALSE
         inc_emissionfactors: TRUE
         inc_stresstest: TRUE
-    
+
     sectors:
         tech_roadmap_sectors:
             - Power
@@ -56,35 +56,35 @@ default:
             - Gas
             - Electric
             - ICE
-            
+
     asset_types:
         - Equity
         - Bonds
         - Others
         - Funds
-        
+
     scenario_sources_list:
         - ETP2017
         - WEO2019
         - WEO2020
         - GECO2019
-      
+
     scenario_geography_list:
         - Global
         - GlobalAggregate
         - NonOECD
         - OECD
-      
+
     equity_market_list:
         - GlobalMarket
         - DevelopedMarket
         - EmergingMarket
-      
-    grouping_variables: 
+
+    grouping_variables:
         - investor_name
-        - portfolio_name  
-        
+        - portfolio_name
+
     stress_test:
         shock_year: 2030
-        
-    
+        price_data_version: 2020Q4
+


### PR DESCRIPTION
closes https://github.com/2DegreesInvesting/PACTA_analysis/issues/369
blocked by https://github.com/2DegreesInvesting/StressTestingModelDev/pull/180

This PR:
- adds a new config field to the `ProjectParameters_CODE.yml` files
- the field structure is `price_data_verson: YYYYQQ` and it is a sub fiel of `stress_test`
- `set_project_parameters()` writes the new config field to a character variable in the `GlobalEnv` (as it does with all other configs)
- as such, the variable is implicitly passed to the stress test when calling `source(file.path(stress_test_path, "web_tool_stress_test.R"))`
- if no such variable is passed for any reason, the stress test script has a default to fall back to (2020Q4 to ensure the swiss project does not change)
- For CHPA2020, I set the previously existing price data version: 2020Q4
- For PA2020FL, I set the price data version: 2020Q4
- For PA2020GENERAL, I set the new price data version 2021Q1, with re-interpolated prices
- For future projects I strongly suggest to always use 2021Q1 (or newer versions)