### PR TITLE
allow a small tolerance after expanding the funds

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1090,7 +1090,7 @@ process_raw_portfolio <- function(portfolio_raw,
 
   portfolio_total <- clean_unmatched_holdings(portfolio_total)
 
-  if (round(sum(portfolio_total$value_usd, na.rm = T), 1) != round(original_value_usd, 1)) {
+  if (!all.equal(sum(portfolio_total$value_usd, na.rm = TRUE), original_value_usd, tolerance = 1e-3)) {
     stop("Fund Portfolio introducing errors in total value")
   }
 


### PR DESCRIPTION
After funds are expanded into individual holdings, the total value of the portfolio may change a small amount. With this check, we now allow for a small tolerance (0.1%) in the difference between the original sum and the new sum.