### PR TITLE
Add choose sectors

### DIFF
--- a/0_portfolio_test.R
+++ b/0_portfolio_test.R
@@ -23,7 +23,8 @@ get_ald_scen <- function(portfolio_type) {
   ald <- ald %>%
     filter(
       scenario_source %in% scenario_sources_list,
-      scenario_geography %in% scenario_geographies_list
+      scenario_geography %in% scenario_geographies_list,
+      ald_sector %in% sector_list
     ) %>%
     mutate(mapped_ald = 1)
 
@@ -44,6 +45,7 @@ get_ald_raw <- function(portfolio_type) {
 
   ald_raw <- ald_raw %>%
     filter(year %in% seq(start_year, start_year + time_horizon)) %>%
+    filter(ald_sector %in% sector_list) %>%
     mutate(
       ald_sector = if_else(technology == "Coal", "Coal", ald_sector),
       ald_sector = if_else(technology %in% c("Oil", "Gas"), "Oil&Gas", ald_sector),

--- a/parameter_files/ProjectParameters_GENERAL.yml
+++ b/parameter_files/ProjectParameters_GENERAL.yml
@@ -32,7 +32,6 @@ default:
             - Oil&Gas
             - Coal
         pacta_sectors_not_analysed:
-            - Shipping
             - Steel
             - Aviation
             - Cement


### PR DESCRIPTION
In order to be able to remove shipping from the report, I've added filters so that you can select which sectors come through in the data. However this hasn't worked for all charts. I guess either we either have to change the chart code - or remove the shipping from the financial data as well. This is required for the general initiative as we are not allowed to use the shipping tech share. 
Perhaps there is an option in which we do not display the technologies in this case (we are allowed to show exposure). Or @MonikaFu is there a simple way for you to ensure Shipping remains on the right, even if it doesn't come through in the ALD? 
![image](https://user-images.githubusercontent.com/32903584/108843855-8e436080-75db-11eb-85ec-84c00fb62772.png)
