### PR TITLE
Slightly improve the title of DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: PACTA.analysis
-Title: What the Package Does (One Line, Title Case)
+Title: Helpers for 'PACTA_analysis'
 Version: 0.0.0.9000
 Authors@R: 
     c(person(given = "Mauro",


### PR DESCRIPTION
This PR makes the title of the underlying package a bit more informative. It touches no code and should be safe to merge. I do this so that I can show a bit of DESCRIPTION in README, as a way to explain that this repo contains an R package (#408).

```r
show_package <- head(readLines("DESCRIPTION"), 3)
writeLines(show_package)
#> Package: PACTA.analysis
#> Title: Helpers for 'PACTA_analysis'
#> Version: 0.0.0.9000
```