### PR TITLE
also export invalidsecurities as CSV

### DIFF
--- a/0_json_functions.R
+++ b/0_json_functions.R
@@ -263,17 +263,13 @@ export_audit_information_jsons <- function(audit_file_ = audit_file,
     portfolio_total_ <- subset(portfolio_total_, investor_name != "Meta Investor")
   }
 
-
-
-
-
   folder_path <- paste0(folder_path, "/")
   if (!is.na(project_name_)) {
     folder_path <- paste0(folder_path, project_name_, "_")
   }
   # function
   export_audit_graph_json(audit_file_, paste0(folder_path, "coveragegraph"))
-  export_audit_invalid_json(portfolio_total_, paste0(folder_path, "invalidsecurities"))
+  export_audit_invalid_data(portfolio_total_, paste0(folder_path, "invalidsecurities"))
   export_audit_textvar_json(portfolio_total_, paste0(folder_path, "coveragetextvar"))
 }
 
@@ -343,7 +339,7 @@ export_audit_graph_json <- function(audit_file__, export_path_full) {
   write(chart_information, file = paste0(export_path_full, ".json"))
 }
 
-export_audit_invalid_json <- function(portfolio_total_, export_path_full) {
+export_audit_invalid_data <- function(portfolio_total_, export_path_full) {
   portfolio_total_ <- portfolio_total_ %>% subset(flag %in% c("Missing currency information", "Negative or missing input value", "Invalid or missing ISIN"))
   portfolio_total_ <- portfolio_total_ %>% select("isin", "market_value", "currency", "flag")
   portfolio_total_ <- portfolio_total_[order(-portfolio_total_$market_value), ]
@@ -352,6 +348,7 @@ export_audit_invalid_json <- function(portfolio_total_, export_path_full) {
   invalidsecurties <- toJSON(portfolio_total_, dataframe = c("columns"))
 
   write(invalidsecurties, file = paste0(export_path_full, ".json"))
+  readr::write_csv(portfolio_total_, file = paste0(export_path_full, ".csv"))
 }
 
 export_audit_textvar_json <- function(portfolio_total_, export_path_full) {

--- a/0_json_functions.R
+++ b/0_json_functions.R
@@ -247,7 +247,7 @@ export_report_content_variables_json <- function(audit_file__ = audit_file,
 }
 
 
-export_audit_information_jsons <- function(audit_file_ = audit_file,
+export_audit_information_data <- function(audit_file_ = audit_file,
                                            portfolio_total_ = portfolio_total,
                                            folder_path = proc_input_path,
                                            project_name_ = NA) {

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -43,10 +43,10 @@ file_location <- file.path(analysis_inputs_path, "cleaned_files")
 
 if (new_data == TRUE) {
   currencies <- get_and_clean_currency_data()
-  
-  
+
+
   total_fund_list <- get_and_clean_total_fund_list_data()
- 
+
    # fund_data <- get_and_clean_fund_data()
   fund_data <- data.frame()
 
@@ -75,7 +75,7 @@ if (new_data == TRUE) {
   )
 } else {
   currencies <- fst::read_fst(file.path(file_location, "currencies.fst"))
-  
+
   read_fst_or_return_null <- function(fst_file) {
     if (!file.exists(fst_file)) {
       return(NULL)
@@ -86,19 +86,19 @@ if (new_data == TRUE) {
 
   fund_data_path <- file.path(file_location, "fund_data.fst")
 
-  
+
   fund_data <- read_fst_or_return_null(fund_data_path)
-  
+
   fund_data$holding_isin <- as.character(fund_data$holding_isin)
   fund_data$fund_isin <- as.character(fund_data$fund_isin)
-  
-  
+
+
   fin_data <- fst::read_fst(file.path(file_location, "fin_data.fst"))
 
   comp_fin_data <- fst::read_fst(file.path(file_location, "comp_fin_data.fst"))
 
   debt_fin_data <- fst::read_fst(file.path(file_location, "debt_fin_data.fst"))
-  
+
   total_fund_list <- fst::read_fst(file.path(file_location, "total_fund_list.fst"))
 
   if (inc_emission_factors) {
@@ -179,7 +179,7 @@ port_weights <- pw_calculations(eq_portfolio, cb_portfolio)
 
 proc_input_path_ <- file.path(proc_input_path, portfolio_name_ref_all)
 
-export_audit_information_jsons(
+export_audit_information_data(
   audit_file_ = audit_file %>% filter(portfolio_name == portfolio_name),
   portfolio_total_ = portfolio_total %>% filter(portfolio_name == portfolio_name),
   folder_path = proc_input_path_


### PR DESCRIPTION
closes #427 

I'm not thrilled about this PR. I don't fully understand what's being exported here or why. I don't know why it was originally exported as JSON and now it needs to be CSV. I don't know if we should be doing the same thing with the other files that are being exported here also. I don't know if we should keep exporting JSON files and also export CSV files, or if we should pick one. That all being said, this resolves #427 with minimal changes so at least we'll be able to track how/when/why this was done.