### PR TITLE
remove sec_mapped_sector as is duplicate finsector

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1416,7 +1416,7 @@ create_audit_file <- function(portfolio_total) {
   audit_file <- portfolio_total %>%
     select(
       all_of(grouping_variables), holding_id, isin, value_usd, company_name, asset_type, has_revenue_data, valid_input,
-      direct_holding, security_mapped_sector, financial_sector, bics_sector, sectors_with_assets, has_ald_in_fin_sector, flag
+      direct_holding, financial_sector, bics_sector, sectors_with_assets, has_ald_in_fin_sector, flag
     )
 
   if (has_revenue == FALSE) {


### PR DESCRIPTION
This column is the same as financial_sector and appears twice in the audit file. Removed for clarity