### PR TITLE
Update deprecated argument to write_csv()

### DIFF
--- a/workflow-pacta-cop.Rmd
+++ b/workflow-pacta-cop.Rmd
@@ -174,7 +174,7 @@ inc_meta_portfolio <- TRUE
 meta_portfolio_name <- "Meta Portfolio"
 meta_investor_name <- "Meta Investor"
 
-write_csv(portfolio_ind, path = file.path(raw_input_path, paste0(project_name, "_Input.csv")))
+write_csv(portfolio_ind, file = file.path(raw_input_path, paste0(project_name, "_Input.csv")))
 ```
 
 If you prepared the input file yourself, add the portfolio files to the folder `{r} file.path(raw_input_path)`. Otherwise this is already done above.
@@ -223,7 +223,7 @@ set_project_parameters(file.path(par_file_path, "ProjectParameters.yml"))
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 
 inc_meta_portfolio <- FALSE
-write_csv(portfolio_peers, path = file.path(raw_input_path, paste0(project_name, "_Input.csv")))
+write_csv(portfolio_peers, file = file.path(raw_input_path, paste0(project_name, "_Input.csv")))
 
 ```
 


### PR DESCRIPTION
Relates to #435. 

Although the modified file does not show output, it should produce this warning:

```r
#> Warning: The `path` argument of `write_csv()` is deprecated as of readr 1.4.0.
#> Please use the `file` argument instead.
```

This PR avoids such warning by using the argument `file` as the warning says.