### PR TITLE
Avoid warning: Extract first element explicitly

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1085,7 +1085,12 @@ process_raw_portfolio <- function(portfolio_raw,
   original_value_usd <- sum(portfolio$value_usd, na.rm = T)
 
   # correct Funds classification by comparing isin to the list of all known funds isins
-  if(!is.null(total_fund_list)){portfolio <- portfolio %>% mutate(asset_type = ifelse(is.element(isin, total_fund_list$fund_isin), "Funds", asset_type))}
+  if (!is.null(total_fund_list)) {
+    portfolio <- portfolio %>%
+      mutate(asset_type = ifelse(
+        is.element(isin, total_fund_list$fund_isin), "Funds", asset_type
+      ))
+  }
   # identify fund in the portfolio
   fund_portfolio <- identify_fund_portfolio(portfolio)
 

--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1085,7 +1085,7 @@ process_raw_portfolio <- function(portfolio_raw,
   original_value_usd <- sum(portfolio$value_usd, na.rm = T)
 
   # correct Funds classification by comparing isin to the list of all known funds isins
-  # FIXME: Looking at the signature and noticing this is the fist use of
+  # FIXME: Looking at the signature and noticing this is the only use of
   # `total_fund_list` I interpret that the author intended to make
   # `total_fund_list` an optional argument and chose as a default the value
   # `NA`. Here I express that intent explicitely but note that not `NA` but

--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1085,7 +1085,12 @@ process_raw_portfolio <- function(portfolio_raw,
   original_value_usd <- sum(portfolio$value_usd, na.rm = T)
 
   # correct Funds classification by comparing isin to the list of all known funds isins
-  if(!is.na(total_fund_list)){portfolio <- portfolio %>% mutate(asset_type = ifelse(is.element(isin, total_fund_list$fund_isin), "Funds", asset_type))}
+
+  # FIXME: When fed with an object of length > 1L, `if()` extracts the first
+  # element !is.na(total_fund_list)[[1]] Extracting the first element explicitly
+  # avoids the warning reported in #436 but is likely wrong. Instead, should we
+  # use `!all(is.na(total_fund_list))`?
+  if(!is.na(total_fund_list)[[1]]){portfolio <- portfolio %>% mutate(asset_type = ifelse(is.element(isin, total_fund_list$fund_isin), "Funds", asset_type))}
   # identify funds in the portfolio
   fund_portfolio <- identify_fund_portfolio(portfolio)
 

--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1085,13 +1085,14 @@ process_raw_portfolio <- function(portfolio_raw,
   original_value_usd <- sum(portfolio$value_usd, na.rm = T)
 
   # correct Funds classification by comparing isin to the list of all known funds isins
-
-  # FIXME: When fed with an object of length > 1L, `if()` extracts the first
-  # element !is.na(total_fund_list)[[1]] Extracting the first element explicitly
-  # avoids the warning reported in #436 but is likely wrong. Instead, should we
-  # use `!all(is.na(total_fund_list))`?
-  if(!is.na(total_fund_list)[[1]]){portfolio <- portfolio %>% mutate(asset_type = ifelse(is.element(isin, total_fund_list$fund_isin), "Funds", asset_type))}
-  # identify funds in the portfolio
+  # FIXME: Looking at the signature and noticing this is the fist use of
+  # `total_fund_list` I interpret that the author intended to make
+  # `total_fund_list` an optional argument and chose as a default the value
+  # `NA`. Here I express that intent explicitely but note that not `NA` but
+  # `NULL` is more commonly used as a default value for optional arguments.
+  total_fund_list_not_passed_as_argument <- identical(total_fund_list, NA)
+  if(total_fund_list_not_passed_as_argument){portfolio <- portfolio %>% mutate(asset_type = ifelse(is.element(isin, total_fund_list$fund_isin), "Funds", asset_type))}
+  # identify fund in the portfolio
   fund_portfolio <- identify_fund_portfolio(portfolio)
 
   if (data_check(fund_data)) {

--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -1049,7 +1049,7 @@ process_raw_portfolio <- function(portfolio_raw,
                                   fund_data,
                                   currencies,
                                   grouping_variables,
-                                  total_fund_list=NA) {
+                                  total_fund_list = NULL) {
   portfolio <- clean_colnames_portfolio_input_file(portfolio_raw)
 
   portfolio <- clear_portfolio_input_blanks(portfolio)
@@ -1085,13 +1085,7 @@ process_raw_portfolio <- function(portfolio_raw,
   original_value_usd <- sum(portfolio$value_usd, na.rm = T)
 
   # correct Funds classification by comparing isin to the list of all known funds isins
-  # FIXME: Looking at the signature and noticing this is the only use of
-  # `total_fund_list` I interpret that the author intended to make
-  # `total_fund_list` an optional argument and chose as a default the value
-  # `NA`. Here I express that intent explicitely but note that not `NA` but
-  # `NULL` is more commonly used as a default value for optional arguments.
-  total_fund_list_not_passed_as_argument <- identical(total_fund_list, NA)
-  if(total_fund_list_not_passed_as_argument){portfolio <- portfolio %>% mutate(asset_type = ifelse(is.element(isin, total_fund_list$fund_isin), "Funds", asset_type))}
+  if(!is.null(total_fund_list)){portfolio <- portfolio %>% mutate(asset_type = ifelse(is.element(isin, total_fund_list$fund_isin), "Funds", asset_type))}
   # identify fund in the portfolio
   fund_portfolio <- identify_fund_portfolio(portfolio)
 

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -306,7 +306,7 @@ save_cleaned_files <- function(save_loc,
                                debt_fin_data,
                                average_sector_intensity,
                                company_emissions,
-                               total_fund_list=NA) {
+                               total_fund_list = NULL) {
   if (!dir.exists(save_loc)) {
     dir.create(save_loc)
   }
@@ -318,14 +318,7 @@ save_cleaned_files <- function(save_loc,
   fst::write_fst(debt_fin_data, file.path(save_loc, "debt_fin_data.fst"))
   fst::write_fst(average_sector_intensity, file.path(save_loc, "average_sector_intensity.fst"))
   fst::write_fst(company_emissions, file.path(save_loc, "company_emissions.fst"))
-  # FIXME: Looking at the signature and noticing this is the only use of
-  # `total_fund_list` I interpret that the author intended to make
-  # `total_fund_list` an optional argument and chose as a default the value
-  # `NA`. Here I express that intent explicitely but note that not `NA` but
-  # `NULL` is more commonly used as a default value for optional arguments.
-  total_fund_list_not_passed_as_argument <- identical(total_fund_list, NA)
-  if (!is.na(total_fund_list_not_passed_as_argument))
-  {fst::write_fst(total_fund_list, file.path(save_loc, "total_fund_list.fst"))}
+  if (!is.null(total_fund_list)) {fst::write_fst(total_fund_list, file.path(save_loc, "total_fund_list.fst"))}
 
   if (check_file_size(save_loc)) warning("File size exceeds what can be pushed to GitHub. Check before Committing")
 }

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -318,6 +318,7 @@ save_cleaned_files <- function(save_loc,
   fst::write_fst(debt_fin_data, file.path(save_loc, "debt_fin_data.fst"))
   fst::write_fst(average_sector_intensity, file.path(save_loc, "average_sector_intensity.fst"))
   fst::write_fst(company_emissions, file.path(save_loc, "company_emissions.fst"))
+  # FIXME: See #436
   if (!is.na(total_fund_list))
   {fst::write_fst(total_fund_list, file.path(save_loc, "total_fund_list.fst"))}
 

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -318,7 +318,9 @@ save_cleaned_files <- function(save_loc,
   fst::write_fst(debt_fin_data, file.path(save_loc, "debt_fin_data.fst"))
   fst::write_fst(average_sector_intensity, file.path(save_loc, "average_sector_intensity.fst"))
   fst::write_fst(company_emissions, file.path(save_loc, "company_emissions.fst"))
-  if (!is.null(total_fund_list)) {fst::write_fst(total_fund_list, file.path(save_loc, "total_fund_list.fst"))}
+  if (!is.null(total_fund_list)) {
+    fst::write_fst(total_fund_list, file.path(save_loc, "total_fund_list.fst"))
+  }
 
   if (check_file_size(save_loc)) warning("File size exceeds what can be pushed to GitHub. Check before Committing")
 }

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -318,8 +318,13 @@ save_cleaned_files <- function(save_loc,
   fst::write_fst(debt_fin_data, file.path(save_loc, "debt_fin_data.fst"))
   fst::write_fst(average_sector_intensity, file.path(save_loc, "average_sector_intensity.fst"))
   fst::write_fst(company_emissions, file.path(save_loc, "company_emissions.fst"))
-  # FIXME: See #436
-  if (!is.na(total_fund_list))
+  # FIXME: Looking at the signature and noticing this is the only use of
+  # `total_fund_list` I interpret that the author intended to make
+  # `total_fund_list` an optional argument and chose as a default the value
+  # `NA`. Here I express that intent explicitely but note that not `NA` but
+  # `NULL` is more commonly used as a default value for optional arguments.
+  total_fund_list_not_passed_as_argument <- identical(total_fund_list, NA)
+  if (!is.na(total_fund_list_not_passed_as_argument))
   {fst::write_fst(total_fund_list, file.path(save_loc, "total_fund_list.fst"))}
 
   if (check_file_size(save_loc)) warning("File size exceeds what can be pushed to GitHub. Check before Committing")


### PR DESCRIPTION
Relates to #436 

When fed with an object of length > 1L, `if()` extracts the first element with a warning. This PR removes such warning in the most backward-compatible way -- by extracting the fist element explicitly. but it also flags `FIXME` because this is likely incorrect and instead we should likely use get an atomic vector with `all()`.

```r
# Okay (backward compatible but likely wrong)
if (long_logical[[1]]) ...

# Likely better
if (all(long_logical)) ...

# Bad
if (long_logical) ...
```
