### PR TITLE
445 offline workflow supervisors

### DIFF
--- a/1_portfolio_check_initialisation.R
+++ b/1_portfolio_check_initialisation.R
@@ -27,6 +27,7 @@ source("0_sda_approach.R")
 
 project_name <- "BondsTest"
 twodii_internal <- TRUE
+run_remotely <- FALSE
 # TRUE or FALSE: TRUE means that the code is running on a 2dii laptop with dropbox connection
 
 #####################################################################

--- a/2b_portfolio_prep_supervisor_workflow.R
+++ b/2b_portfolio_prep_supervisor_workflow.R
@@ -1,0 +1,28 @@
+financial_data <- readRDS(file.path(analysis_inputs_path, "financial_data.rda"))
+raw_pf <- read_csv(file.path(raw_input_path, paste0(project_name, "_Input.csv")),
+                   col_types = "cccnnccn")
+
+
+prep_pf <- raw_pf %>%
+  inner_join(financial_data, by = "isin") %>%
+  add_holding_id() %>%
+  rename(current_shares_outstanding_all_classes = current_shares_outstanding)
+
+port_raw_all_eq <- prep_pf %>%
+  filter(asset_type == "Equity") %>%
+  mutate(
+    id = company_id,
+    id_name = "company_id"
+  )
+
+port_raw_all_eq %>% write_rds(file.path(proc_input_path, paste0(project_name, "_equity_portfolio.rda")))
+
+
+port_raw_all_cb <- prep_pf %>%
+  filter(asset_type == "Bonds") %>%
+  mutate(
+    id = corporate_bond_ticker,
+    id_name = "corporate_bond_ticker"
+  )
+
+port_raw_all_cb %>% write_rds(file.path(proc_input_path, paste0(project_name, "_bonds_portfolio.rda")))

--- a/2b_portfolio_prep_supervisor_workflow.R
+++ b/2b_portfolio_prep_supervisor_workflow.R
@@ -1,3 +1,5 @@
+# use this script instead of script 2, in case the logical run_remotely == TRUE
+
 financial_data <- readRDS(file.path(analysis_inputs_path, "financial_data.rda"))
 raw_pf <- read_csv(file.path(raw_input_path, paste0(project_name, "_Input.csv")),
                    col_types = "cccnnccn")

--- a/3_run_analysis.R
+++ b/3_run_analysis.R
@@ -9,12 +9,12 @@ port_col_types <- set_col_types(grouping_variables, "ddddccccddclc")
 equity_input_file <- paste0(proc_input_path, "/", project_name, "_equity_portfolio.rda")
 
 if (file.exists(equity_input_file)) {
-  port_raw_all_eq <- read_rds(equity_input_file) %>%
-    mutate(id = as.character(id))
+  port_raw_all_eq <- read_rds(equity_input_file) #%>%
+    # mutate(id = as.character(id))
 
-  if (length(colnames(port_raw_all_eq)) != nchar(port_col_types)) {
-    stop("Check port_col_types: difference in length")
-  }
+  # if (length(colnames(port_raw_all_eq)) != nchar(port_col_types)) {
+  #   stop("Check port_col_types: difference in length")
+  # }
 
   ald_scen_eq <- get_ald_scen("Equity")
 
@@ -97,12 +97,12 @@ if (file.exists(equity_input_file)) {
 bonds_inputs_file <- paste0(proc_input_path, "/", project_name, "_bonds_portfolio.rda")
 
 if (file.exists(bonds_inputs_file)) {
-  port_raw_all_cb <- read_rds(bonds_inputs_file) %>%
-    mutate(id = as.character(id))
+  port_raw_all_cb <- read_rds(bonds_inputs_file) #%>%
+    # mutate(id = as.character(id))
 
-  if (length(colnames(port_raw_all_cb)) != nchar(port_col_types)) {
-    stop("Check port_col_types: difference in length")
-  }
+  # if (length(colnames(port_raw_all_cb)) != nchar(port_col_types)) {
+  #   stop("Check port_col_types: difference in length")
+  # }
 
   ald_scen_cb <- get_ald_scen("Bonds")
 

--- a/3_run_analysis.R
+++ b/3_run_analysis.R
@@ -1,7 +1,10 @@
 # TODO:
 # Clean up sectors options
 
-port_col_types <- set_col_types(grouping_variables, "ddddccccddclc")
+if(run_remotely == FALSE) {
+  port_col_types <- set_col_types(grouping_variables, "ddddccccddclc")
+}
+
 ##################
 ##### EQUITY #####
 ##################
@@ -9,16 +12,25 @@ port_col_types <- set_col_types(grouping_variables, "ddddccccddclc")
 equity_input_file <- paste0(proc_input_path, "/", project_name, "_equity_portfolio.rda")
 
 if (file.exists(equity_input_file)) {
-  port_raw_all_eq <- read_rds(equity_input_file) #%>%
-    # mutate(id = as.character(id))
 
-  # if (length(colnames(port_raw_all_eq)) != nchar(port_col_types)) {
-  #   stop("Check port_col_types: difference in length")
-  # }
+  if(run_remotely == FALSE) {
+
+    port_raw_all_eq <- read_rds(equity_input_file) %>%
+    mutate(id = as.character(id))
+
+    if (length(colnames(port_raw_all_eq)) != nchar(port_col_types)) {
+      stop("Check port_col_types: difference in length")
+    }
+
+  } else {
+    port_raw_all_eq <- read_rds(equity_input_file)
+  }
 
   ald_scen_eq <- get_ald_scen("Equity")
 
-  ald_raw_eq <- get_ald_raw("Equity")
+  if(has_map) {
+    ald_raw_eq <- get_ald_raw("Equity")
+  }
 
   list_investors_eq <- unique(port_raw_all_eq$investor_name)
 
@@ -97,16 +109,24 @@ if (file.exists(equity_input_file)) {
 bonds_inputs_file <- paste0(proc_input_path, "/", project_name, "_bonds_portfolio.rda")
 
 if (file.exists(bonds_inputs_file)) {
-  port_raw_all_cb <- read_rds(bonds_inputs_file) #%>%
-    # mutate(id = as.character(id))
 
-  # if (length(colnames(port_raw_all_cb)) != nchar(port_col_types)) {
-  #   stop("Check port_col_types: difference in length")
-  # }
+  if(run_remotely == FALSE) {
+    port_raw_all_cb <- read_rds(bonds_inputs_file) %>%
+    mutate(id = as.character(id))
+
+    if (length(colnames(port_raw_all_cb)) != nchar(port_col_types)) {
+      stop("Check port_col_types: difference in length")
+    }
+
+  } else {
+    port_raw_all_cb <- read_rds(bonds_inputs_file)
+  }
 
   ald_scen_cb <- get_ald_scen("Bonds")
 
-  ald_raw_cb <- get_ald_raw("Bonds")
+  if(has_map) {
+    ald_raw_cb <- get_ald_raw("Bonds")
+  }
 
   list_investors_cb <- unique(port_raw_all_cb$investor_name)
 


### PR DESCRIPTION
closes #445 

This PR:

- adds an alternative second step to the offline PACTA workflow
- this step can be used to prepare the portfolio data whenever the user needs to run PACTA offline on their own machines and cannot grant us access to any of their data
- It requires different input data from our side (and the user's side!), as described [here](https://docs.google.com/document/d/1p-k4M1-ku8y6UIsFrZLhAdUzNoZDcMiLn36RIAxZkoY/edit#heading=h.7fb5m5qd2r64)
- It leads to a new workflow, described in detail [here](https://docs.google.com/document/d/1rBMLBOtQJGwoQVGjy6qRH71hiv9XFeXMI86eE50yunQ/edit#)
- introduces a boolean that indicates whether the script is to be run remotely or not
- runs checks and definitions of column types based on that boolean as they differ between the workflows.

Note:

- I am absolutely open to discussing the implementation of this workflow, as some of the choices I made are rather for reasons of getting this out soon than for thoroughly thought through reasons regarding future restructuring of the package.