### PR TITLE
number_of_shares should always be numeric

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -200,7 +200,7 @@ check_missing_cols <- function(portfolio, grouping_variables) {
   required_input_cols <- c("holding_id", "market_value", "currency", "isin", grouping_variables, "number_of_shares")
 
   if (!"number_of_shares" %in% colnames(portfolio)) {
-    portfolio$number_of_shares <- NA
+    portfolio$number_of_shares <- NA_real_
   }
 
 


### PR DESCRIPTION
if number_of_shares is not in the original portfolio CSV, then it is added... but it should be added as a numeric vector filled with NAs rather than a logical vector filled with NAs