### PR TITLE
add a file encoding check action on PR

### DIFF
--- a/.github/workflows/pr-check-file-encodings.yml
+++ b/.github/workflows/pr-check-file-encodings.yml
@@ -1,0 +1,21 @@
+name: check file encodings in PR
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: run the checkout action
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: list all changed files
+        run: |
+          files=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)
+          IFS=$'\n'; files=($files); unset IFS;  # split the string into an array
+          file --mime "${files[@]}"
+      - name: list all changed files with the wrong encoding
+        run: |
+          files=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)
+          IFS=$'\n'; files=($files); unset IFS;  # split the string into an array
+          ! file --mime "${files[@]}" | grep -v "charset=utf-8\|charset=us-ascii\|charset=binary"


### PR DESCRIPTION
adds a GitHub Action that will trigger on any commit on a PR, that will check the file encoding of every file that has been modified in that PR (unless it's a binary file) and trigger and error if any of the files are not either UTF-8 or ASCII