### PR TITLE
enable encoding action to work on PR from a fork

### DIFF
--- a/.github/workflows/pr-check-file-encodings.yml
+++ b/.github/workflows/pr-check-file-encodings.yml
@@ -11,11 +11,11 @@ jobs:
           fetch-depth: 0
       - name: list all changed files
         run: |
-          files=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)
+          files=$(git diff --name-only origin/$GITHUB_BASE_REF...${{ github.sha }})
           IFS=$'\n'; files=($files); unset IFS;  # split the string into an array
           file --mime "${files[@]}"
       - name: list all changed files with the wrong encoding
         run: |
-          files=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)
+          files=$(git diff --name-only origin/$GITHUB_BASE_REF...${{ github.sha }})
           IFS=$'\n'; files=($files); unset IFS;  # split the string into an array
           ! file --mime "${files[@]}" | grep -v "charset=utf-8\|charset=us-ascii\|charset=binary"


### PR DESCRIPTION
replacing `origin/$GITHUB_HEAD_REF` with `${{ github.sha }}` enables this action to determine the diff even if the PR originates from a fork (versus a feature branch in the same repo)