### PR TITLE
Update package-documentation

### DIFF
--- a/man/write_csv_file.Rd
+++ b/man/write_csv_file.Rd
@@ -24,12 +24,30 @@ will append to existing file. In both cases, if the file does not exist a new
 file is created.}
     \item{\code{col_names}}{If \code{FALSE}, column names will not be included at the top of the file. If \code{TRUE},
 column names will be included. If not specified, \code{col_names} will take the opposite value given to \code{append}.}
-    \item{\code{quote_escape}}{The type of escaping to use for quoted values, one of
-\code{"double"}, \code{"backslash"} or \code{"none"}. You can also use \code{FALSE}, which is
-equivalent to "none". The default is \code{"double"}, which is expected format for Excel.}
+    \item{\code{quote}}{How to handle fields which contain characters that need to be quoted.
+\itemize{
+\item \code{needed} - Only quote fields which need them.
+\item \code{all} - Quote all fields.
+\item \code{none} - Never quote fields.
+}}
+    \item{\code{escape}}{The type of escape to use when quotes are in the data.
+\itemize{
+\item \code{double} - quotes are escaped by doubling them.
+\item \code{backslash} - quotes are escaped by a preceding backslash.
+\item \code{none} - quotes are not escaped.
+}}
     \item{\code{eol}}{The end of line character to use. Most commonly either \code{"\n"} for
 Unix style newlines, or \code{"\r\n"} for Windows style newlines.}
-    \item{\code{path}}{\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}}
+    \item{\code{num_threads}}{Number of threads to use when reading and materializing
+vectors. If your data contains newlines within fields the parser will
+automatically be forced to use a single thread only.}
+    \item{\code{progress}}{Display a progress bar? By default it will only display
+in an interactive session and not while knitting a document. The display
+is updated every 50,000 values and will only display if estimated reading
+time is 5 seconds or more. The automatic progress bar can be disabled by
+setting option \code{readr.show_progress} to \code{FALSE}.}
+    \item{\code{path}}{\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}, use the \code{file} argument instead.}
+    \item{\code{quote_escape}}{\Sexpr[results=rd, stage=render]{lifecycle::badge("deprecated")}, use the \code{escape} argument instead.}
   }}
 }
 \description{


### PR DESCRIPTION
This PR updates the documentation of the PACTA.analysis package.

Note that the source of the documentation did not change, only
the rendered man/ file. This may be because readr updated the
source, and we inherit documentation from readr. So running
`devtools::document()` with no changes in `R/<filename>.R` does 
produce changes in `man/<filename>.Rd`.﻿
