### PR TITLE
933 supervisor wf flags and overview

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -4,7 +4,7 @@
 # docker image: https://github.com/Tazinho/snakecase/issues/191
 # explanation: I believe snakecase:::replace_special_characters_internal is only a promise until
 # the first time it is called, so simply printing the function to stdout causes the function to
-# be loaded for the first time, triggering the warnings, thereby relieving any further calls 
+# be loaded for the first time, triggering the warnings, thereby relieving any further calls
 # to it from additional warnings
 # because janitor::clean_names() is used in multiple functions here, this is the cleanest way
 # to deal with them all at once up front
@@ -706,6 +706,19 @@ check_valid_input_value <- function(portfolio_total) {
       TRUE ~ TRUE
     ))
 
+  portfolio_total
+}
+
+check_valid_value_usd <- function(portfolio_total) {
+  portfolio_total <- portfolio_total %>%
+    mutate(
+      has_valid_value_usd = case_when(
+        is.na(value_usd) & is.na(number_of_shares) ~ FALSE,
+        value_usd < 0 ~ FALSE,
+        number_of_shares < 0 ~ FALSE,
+        TRUE ~ TRUE
+      )
+    )
   portfolio_total
 }
 

--- a/0_portfolio_test.R
+++ b/0_portfolio_test.R
@@ -33,21 +33,21 @@ get_ald_scen <- function(portfolio_type) {
   return(ald)
 }
 
-get_ald_raw <- function(portfolio_type) {
+get_ald_raw <- function(portfolio_type, supervisor_workflow = FALSE) {
+  if (supervisor_workflow == TRUE) {
+    filename_eq_raw <- "equity_ald_scenario_map.rda"
+    filename_cb_raw <- "bonds_ald_scenario_map.rda"
+  } else {
+    filename_eq_raw <- "masterdata_ownership_datastore.rda"
+    filename_cb_raw <- "masterdata_debt_datastore.rda"
+  }
+
   if (portfolio_type == "Equity") {
-    if (twodii_internal == FALSE & run_remotely == TRUE) {
-      ald_raw <- read_rds(paste0(analysis_inputs_path, "/equity_ald_scenario_map.rda"))
-    } else {
-      ald_raw <- read_rds(paste0(analysis_inputs_path, "/masterdata_ownership_datastore.rda"))
-    }
+    ald_raw <- read_rds(file.path(analysis_inputs_path, filename_eq_raw))
   }
 
   if (portfolio_type == "Bonds") {
-    if (twodii_internal == FALSE & run_remotely == TRUE) {
-      ald_raw <- read_rds(paste0(analysis_inputs_path, "/bonds_ald_scenario_map.rda"))
-    } else {
-      ald_raw <- read_rds(paste0(analysis_inputs_path, "/masterdata_debt_datastore.rda"))
-    }
+    ald_raw <- read_rds(file.path(analysis_inputs_path, filename_cb_raw))
   }
 
 

--- a/0_portfolio_test.R
+++ b/0_portfolio_test.R
@@ -35,11 +35,19 @@ get_ald_scen <- function(portfolio_type) {
 
 get_ald_raw <- function(portfolio_type) {
   if (portfolio_type == "Equity") {
-    ald_raw <- read_rds(paste0(analysis_inputs_path, "/masterdata_ownership_datastore.rda"))
+    if (twodii_internal == FALSE & run_remotely == TRUE) {
+      ald_raw <- read_rds(paste0(analysis_inputs_path, "/equity_ald_scenario_map.rda"))
+    } else {
+      ald_raw <- read_rds(paste0(analysis_inputs_path, "/masterdata_ownership_datastore.rda"))
+    }
   }
 
   if (portfolio_type == "Bonds") {
-    ald_raw <- read_rds(paste0(analysis_inputs_path, "/masterdata_debt_datastore.rda"))
+    if (twodii_internal == FALSE & run_remotely == TRUE) {
+      ald_raw <- read_rds(paste0(analysis_inputs_path, "/bonds_ald_scenario_map.rda"))
+    } else {
+      ald_raw <- read_rds(paste0(analysis_inputs_path, "/masterdata_debt_datastore.rda"))
+    }
   }
 
 

--- a/3_run_analysis.R
+++ b/3_run_analysis.R
@@ -5,6 +5,10 @@ if(run_remotely == FALSE) {
   port_col_types <- set_col_types(grouping_variables, "ddddccccddclc")
 }
 
+# indicator used to pick correct file names later on - ADO 933
+use_supervisor_workflow <- dplyr::if_else(twodii_internal == FALSE & run_remotely == TRUE, TRUE, FALSE)
+
+
 ##################
 ##### EQUITY #####
 ##################
@@ -29,7 +33,10 @@ if (file.exists(equity_input_file)) {
   ald_scen_eq <- get_ald_scen("Equity")
 
   if(has_map) {
-    ald_raw_eq <- get_ald_raw("Equity")
+    ald_raw_eq <- get_ald_raw(
+      portfolio_type = "Equity",
+      supervisor_workflow = use_supervisor_workflow
+    )
   }
 
   list_investors_eq <- unique(port_raw_all_eq$investor_name)
@@ -125,7 +132,10 @@ if (file.exists(bonds_inputs_file)) {
   ald_scen_cb <- get_ald_scen("Bonds")
 
   if(has_map) {
-    ald_raw_cb <- get_ald_raw("Bonds")
+    ald_raw_cb <- get_ald_raw(
+      portfolio_type = "Bonds",
+      supervisor_workflow = use_supervisor_workflow
+    )
   }
 
   list_investors_cb <- unique(port_raw_all_cb$investor_name)


### PR DESCRIPTION
closes ADO 933: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/933

all changes below refer to the supervisor workflow.

These changes are required to provide the relevant files to the stress testing script after running PACTA EQ/CB with the supervisor workflow

This PR:
- adds some validity flags to the portfolio in the preparation script of the supervisor workflow
- returns `total_portfolio` in the supervisor workflow and saves it to the `30_Processed_Inputs` directory
- returns `overview_portfolio` in the supervisor workflow and saves it to the `30_Processed_Inputs` directory
- adds functionality to `get_ald_raw()` in `portfolio_test.R`, so that it will automatically read the correct file in the supervisor workflow and go on as before in any other workflow