### PR TITLE
move stress testing to webtool 3 so webtool 1-2 is only the "PACTA" p…

### DIFF
--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -209,14 +209,6 @@ if (file.exists(bonds_inputs_file)) {
   }
 }
 
-# provide parameters for stress test
-invisible(set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_name_ref_all, "_PortfolioParameters.yml"))))
-# set environment variable for stress test data path
-options("ST_DATA_PATH" = stress_test_data_location)
-# run 2dii stress test
-source(file.path(stress_test_path, "web_tool_stress_test.R"))
-# run stress test with external scenarios (IPR)
-source(file.path(stress_test_path, "web_tool_external_stress_test.R"))
 
 rm(port_raw_all_eq)
 rm(port_raw_all_cb)

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -32,6 +32,21 @@ if(project_code == "GENERAL"){
 
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 
+
+# stress test -------------------------------------------------------------
+
+# provide parameters for stress test
+invisible(set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_name_ref_all, "_PortfolioParameters.yml"))))
+# set environment variable for stress test data path
+options("ST_DATA_PATH" = stress_test_data_location)
+# run 2dii stress test
+source(file.path(stress_test_path, "web_tool_stress_test.R"))
+# run stress test with external scenarios (IPR)
+source(file.path(stress_test_path, "web_tool_external_stress_test.R"))
+
+
+# create interactive report -----------------------------------------------
+
 source(file.path(template_path, "create_interactive_report.R"))
 source(file.path(template_path, "create_executive_summary.R"))
 source(file.path(template_path, "useful_functions.R"))


### PR DESCRIPTION
…rocess

this has been a long time coming.... I don't know the history of why stress testing was added to web tool script 2... I guess because the results of it were needed to create the interactive report? Anyway, this finally cleanly separates "doing PACTA" and "doing something with the results of PACTA". I think this is a good step toward a lot of the ideas/discussions we've had about making the web tool easier to use in different contexts, separating running PACTA from doing stuff with the PACTA outputs, etc.

To be honest, I didn't put a whole lot of thought into this, so I'd be happy if many of you take a look and share any thought or concerns. (also tagging @andybue who I can't add as a reviewer?)