### PR TITLE
enable setting data_location_ext based on the financial_timestamp in …

### DIFF
--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -85,7 +85,7 @@ set_web_parameters <- function(file_path) {
   twodii_internal <<- cfg$parameters$twodii_internal
   new_data <<- cfg$parameters$new_data
 
-  financial_timestamp <<- cfg$parameters$financial_timestamp
+  # financial_timestamp <<- cfg$parameters$financial_timestamp
 }
 
 set_portfolio_parameters <- function(file_path) {

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -23,6 +23,9 @@ set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_na
 
 set_project_parameters(file.path(working_location, "parameter_files",paste0("ProjectParameters_", project_code, ".yml")))
 
+data_location_ext <- sub("[0-9]{4}Q[0-9]", financial_timestamp, data_location_ext)
+
+
 # need to define an alternative location for data files
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -23,7 +23,7 @@ set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_na
 
 set_project_parameters(file.path(working_location, "parameter_files",paste0("ProjectParameters_", project_code, ".yml")))
 
-data_location_ext <- sub("[0-9]{4}Q[0-9]", financial_timestamp, data_location_ext)
+data_location_ext <- sub("20[0-9]{2}Q[1-4]", financial_timestamp, data_location_ext)
 
 
 # need to define an alternative location for data files

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -24,7 +24,7 @@ set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_na
 
 set_project_parameters(file.path(working_location, "parameter_files", paste0("ProjectParameters_", project_code, ".yml")))
 
-data_location_ext <- sub("[0-9]{4}Q[0-9]", financial_timestamp, data_location_ext)
+data_location_ext <- sub("20[0-9]{2}Q[1-4]", financial_timestamp, data_location_ext)
 
 # need to define an alternative location for data files
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -24,6 +24,8 @@ set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_na
 
 set_project_parameters(file.path(working_location, "parameter_files", paste0("ProjectParameters_", project_code, ".yml")))
 
+data_location_ext <- sub("[0-9]{4}Q[0-9]", financial_timestamp, data_location_ext)
+
 # need to define an alternative location for data files
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -17,6 +17,8 @@ set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_na
 
 set_project_parameters(file.path(working_location, "parameter_files",paste0("ProjectParameters_", project_code, ".yml")))
 
+data_location_ext <- sub("[0-9]{4}Q[0-9]", financial_timestamp, data_location_ext)
+
 if(project_code == "PA2020FL"){
   peer_group = case_when(
     peer_group %in% c("other")~ "Others",

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -17,7 +17,7 @@ set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_na
 
 set_project_parameters(file.path(working_location, "parameter_files",paste0("ProjectParameters_", project_code, ".yml")))
 
-data_location_ext <- sub("[0-9]{4}Q[0-9]", financial_timestamp, data_location_ext)
+data_location_ext <- sub("20[0-9]{2}Q[1-4]", financial_timestamp, data_location_ext)
 
 if(project_code == "PA2020FL"){
   peer_group = case_when(


### PR DESCRIPTION
enable setting data_location_ext based on the financial_timestamp in the project parameters

In the past, `data_location_ext` was set when running `setup_project()`, which sources [deduplicate/set_portfolio-name-ref-all_working-location_and_web-parameters.R](https://github.com/2DegreesInvesting/PACTA_analysis/blob/master/deduplicate/set_portfolio-name-ref-all_working-location_and_web-parameters.R), which calls [`set_web_parameters()`](https://github.com/2DegreesInvesting/PACTA_analysis/blob/897433f71c18edb6ba2cf6798f4c961158f27b0d/0_web_functions.R#L74-L89), which loads either [parameter_files/WebParameters_docker.yml](https://github.com/2DegreesInvesting/PACTA_analysis/blob/master/parameter_files/WebParameters_docker.yml) or [parameter_files/WebParameters_2dii.yml](https://github.com/2DegreesInvesting/PACTA_analysis/blob/master/parameter_files/WebParameters_2dii.yml), both of which hard code the location of the 2019Q4 data with `data_location_ext: ../pacta-data/2019Q4/`. Later, [`set_project_parameters()`](https://github.com/2DegreesInvesting/PACTA_analysis/blob/11ea54588f9b618c6f1b09c5f712146f5f0628f3/0_global_functions.R#L46-L128) is run, which loads the appropriate, project specific parameter file, which is where the `financial_timestamp` is usually set with something like `timestamp: 2020Q4`. There are also "portfolio parameters" that are loaded, but only the current "project parameter" files contain a timestamp which can then be used to determine which input data to use. It's possible that `setup_project()` was originally intended to load a file that contains all settings in one, rather than 3 separate parameter files with potentially overlapping settings, but as it is now, all 3 are necessary. That may actually be advantageous because I can imagine cases where there should be some cascading preferences, e.g. project sets default language to EN but user wants report in DE, but this process has not been well thought out.

In order to get 2020Q4 working, we need to set `data_location_ext` to `../pacta-data/2020Q4/`. It probably should be that `data_location_ext` is set to `../pacta-data/`, and then the `financial_timestamp` should be appended to it to get the final location of the data. However, that would likely require a change that would impact existing 2019Q4 accounts and their parameter files, so I'm avoiding that option.

Instead, what I do here is wait till all 3 parameter files have been loaded (in each of the web tool scripts because they all run in a unique environment). At that point `data_location_ext` should have been set by the "web parameters" file, and `financial_timestamp` should have been set by the "project parameters" file, so I'm simply combining them to set the real `data_location_ext` with `data_location_ext <- sub("[0-9]{4}Q[0-9]", financial_timestamp, data_location_ext)`.

Additionally, I've modified [`set_project_parameters()`](https://github.com/2DegreesInvesting/PACTA_analysis/blob/11ea54588f9b618c6f1b09c5f712146f5f0628f3/0_global_functions.R#L46-L128) so that it does not set `financial_timestamp`, which is as of yet is never included in the "web parameters" files, so it always sets `financial_timestamp` to `NULL`. This is particularly a problem when the stress test code runs and reloads the "web parameters" file but not the "project parameters" file.

These code changes should probably be commented, and the commented code deleted, but for now I left it like this or brevity.

interested in thoughts from @AlexAxthelm @jdhoffa @maurolepore @jacobvjk @MirijaHa @catarinabrg @daisy-pacheco @fariiaakh 

I believe that using the 2020Q4 data on transitionmonitor is blocked by https://github.com/2DegreesInvesting/r2dii.stress.test.data/issues/28 because the stress testing bit cannot complete without error
