### PR TITLE
enable setting/overriding data_location_ext in the project parameters

### DIFF
--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -46,6 +46,10 @@ set_col_types <- function(grouping_variables, fixed_col_types) {
 set_project_parameters <- function(file_path){
   cfg <- config::get(file = file_path)
 
+  if (!is.null(cfg$paths$data_location_ext)) {
+    data_location_ext <<- cfg$paths$data_location_ext
+  }
+
   project_report_name <<- cfg$reporting$project_report_name
   display_currency <<- cfg$reporting$display_currency
   currency_exchange_value <<- as.numeric(cfg$reporting$currency_exchange_value)

--- a/parameter_files/ProjectParameters_PA2021NO.yml
+++ b/parameter_files/ProjectParameters_PA2021NO.yml
@@ -1,14 +1,17 @@
 default:
 
+    paths:
+        data_location_ext: ../pacta-data/2020Q4/
+
     reporting:
         project_report_name: norway
         display_currency: NOK
         currency_exchange_value: 0.11
 
     parameters:
-        timestamp: 2019Q4
-        dataprep_timestamp: 2019Q4_250220
-        start_year: 2020
+        timestamp: 2020Q4
+        dataprep_timestamp: 2020Q4_transitionmonitor
+        start_year: 2021
         horizon_year: 5
         select_scenario: WEO2019_SDS
         scenario_auto: ETP2017_B2DS


### PR DESCRIPTION
supersedes #482

enable setting/overriding data_location_ext in the project parameters

in the future, when needing to set a project to use any dataset other than the default `data_location_ext: ../pacta-data/2019Q4/`, the "*project* parameters" file should have something like...
```yaml
        paths:
                data_location_ext: ../pacta-data/2020Q4/
```

because the "*project* parameters" file is always loaded *after* the default "web parameters" file, the `data_location_ext` value in the "*project* parameters" file will override the value from the "web parameters" file (the `setup_project()` function loads the default "web parameters" file, and the `set_project_parameters()` function loads the "project parameters" file).
https://github.com/2DegreesInvesting/PACTA_analysis/blob/897433f71c18edb6ba2cf6798f4c961158f27b0d/web_tool_script_1.R#L16-L24
https://github.com/2DegreesInvesting/PACTA_analysis/blob/897433f71c18edb6ba2cf6798f4c961158f27b0d/web_tool_script_2.R#L17-L25
https://github.com/2DegreesInvesting/PACTA_analysis/blob/897433f71c18edb6ba2cf6798f4c961158f27b0d/web_tool_script_3.R#L12-L18

This is also currently the case with both web tool scripts in stress testing...
https://github.com/2DegreesInvesting/r2dii.climate.stress.test/blob/2f80bdd3875c0abf1bd1f9fe6b4d9de12c0d4dc5/web_tool_external_stress_test.R#L31-L48
https://github.com/2DegreesInvesting/r2dii.climate.stress.test/blob/2f80bdd3875c0abf1bd1f9fe6b4d9de12c0d4dc5/web_tool_stress_test.R#L56-L79

One long term consideration is that the stress testing tool/s do not currently load the "*portfolio* parameters" files, so if we ever enable some cascading of preferences between default, project and portfolio, then we may need to add that to stress testing, and also review the order in which we load them to enable the proper cascading precedence.