### PR TITLE
Update version of roxygen2 in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2


### PR DESCRIPTION
This PR touches no production code. It only updates the
version number of roxygen2 in DESCRIPTION. This happens
automatically when I run `devtools::document()` with a
newer version of roxygen2 installed in my system.
With an older version of roxygen2, R CMD check refuses
to document when I run `devtools::check()`.﻿
