### PR TITLE
use analysis_inputs_path instead because it is overwritten by stress test

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -149,33 +149,33 @@ if (file.exists(file.path(results_path, portfolio_name_ref_all, "Stress_test_res
 }
 
 # load peers results both individual and aggregate
-if (file.exists(file.path(data_location_ext, paste0(project_code, "_peers_equity_results_portfolio.rda")))){
-  peers_equity_results_portfolio <- read_rds(file.path(data_location_ext, paste0(project_code, "_peers_equity_results_portfolio.rda")))
+if (file.exists(file.path(analysis_inputs_path, paste0(project_code, "_peers_equity_results_portfolio.rda")))){
+  peers_equity_results_portfolio <- read_rds(file.path(analysis_inputs_path, paste0(project_code, "_peers_equity_results_portfolio.rda")))
 }else{
   peers_equity_results_portfolio <- empty_portfolio_results()
 }
 
-if(file.exists(file.path(data_location_ext, paste0(project_code, "_peers_bonds_results_portfolio.rda")))){
-  peers_bonds_results_portfolio <- read_rds(file.path(data_location_ext, paste0(project_code, "_peers_bonds_results_portfolio.rda")))
+if(file.exists(file.path(analysis_inputs_path, paste0(project_code, "_peers_bonds_results_portfolio.rda")))){
+  peers_bonds_results_portfolio <- read_rds(file.path(analysis_inputs_path, paste0(project_code, "_peers_bonds_results_portfolio.rda")))
 }else{
   peers_bonds_results_portfolio <- empty_portfolio_results()
 }
 
-if (file.exists(file.path(data_location_ext, paste0(project_code, "_peers_equity_results_portfolio_ind.rda")))){
-  peers_equity_results_user <- read_rds(file.path(data_location_ext, paste0(project_code, "_peers_equity_results_portfolio_ind.rda")))
+if (file.exists(file.path(analysis_inputs_path, paste0(project_code, "_peers_equity_results_portfolio_ind.rda")))){
+  peers_equity_results_user <- read_rds(file.path(analysis_inputs_path, paste0(project_code, "_peers_equity_results_portfolio_ind.rda")))
 }else{
   peers_equity_results_user <- empty_portfolio_results()
 }
 
-if(file.exists(file.path(data_location_ext, paste0(project_code, "_peers_bonds_results_portfolio_ind.rda")))){
-  peers_bonds_results_user <- read_rds(file.path(data_location_ext, paste0(project_code, "_peers_bonds_results_portfolio_ind.rda")))
+if(file.exists(file.path(analysis_inputs_path, paste0(project_code, "_peers_bonds_results_portfolio_ind.rda")))){
+  peers_bonds_results_user <- read_rds(file.path(analysis_inputs_path, paste0(project_code, "_peers_bonds_results_portfolio_ind.rda")))
 }else{
   peers_bonds_results_user <- empty_portfolio_results()
 }
 
-indices_equity_results_portfolio <- read_rds(file.path(data_location_ext, "Indices_equity_portfolio.rda"))
+indices_equity_results_portfolio <- read_rds(file.path(analysis_inputs_path, "Indices_equity_portfolio.rda"))
 
-indices_bonds_results_portfolio <- read_rds(file.path(data_location_ext, "Indices_bonds_portfolio.rda"))
+indices_bonds_results_portfolio <- read_rds(file.path(analysis_inputs_path, "Indices_bonds_portfolio.rda"))
 
 dataframe_translations <- readr::read_csv(
   path(template_path, "data/translation/dataframe_labels.csv"),


### PR DESCRIPTION
@jacobvjk in #483 I enabled a feature that allows the project parameters file to set a project specific `data_location_ext`, which overrides the `data_location_ext` set by the "web_parameters" file when running `setup_project()` (which used to be the only place where this was set). This is what enables us to choose to use the new 2020Q4 data on a project-by-project basis. To achieve that, I added these lines to the top of the `set_project_parameters()` function...

https://github.com/2DegreesInvesting/PACTA_analysis/blob/1cf06b10976b47332e894d63ddc18ced8a2a8522/0_global_functions.R#L49-L51

I thought this completely solved the problem, but.... I've now realized that when I run [web_tool_stress_test.R](https://github.com/2DegreesInvesting/r2dii.climate.stress.test/blob/master/web_tool_stress_test.R) (and likewise with [web_tool_external_stress_test.R](https://github.com/2DegreesInvesting/r2dii.climate.stress.test/blob/master/web_tool_external_stress_test.R)), it defines it's [own version](https://github.com/2DegreesInvesting/r2dii.climate.stress.test/blob/46c4d2968168aa148411d147e14fc9ad782ec2c6/R/set_params_st.R) of `set_project_parameters()` which does not have the new change to allow a project specific `data_location_ext`, overwriting the existing `set_project_parameters()` from PACTA_analysis, which then leads to the stress testing running `setup_project()` which will set the `data_location_ext` back to the default set by the "web_parameters" file (2019Q4), and it then it runs its new `set_project_parameters()` which doesn't respect the project specific `data_location_ext`, so then `data_location_ext` can then be permanently corrupted even back on the PACTA side... AND even if I run  `set_project_parameters()` again in the PACTA script after the stress test is run, I end up using the stress test version of `set_project_parameters()` which doesn't respect the `data_location_ext` setting anyway.

So, all that is to say that I strongly encourage you to update [your version](https://github.com/2DegreesInvesting/r2dii.climate.stress.test/blob/46c4d2968168aa148411d147e14fc9ad782ec2c6/R/set_params_st.R) of `set_project_parameters()` so that it also respects the project specific setting of `data_location_ext`.

But it's no rush for me, because in this PR I have used `analysis_inputs_path` instead of `data_location_ext` downstream because it is set to the value of `data_location_ext` before the stress test runs, so it retains the 2020Q4 path if that is what is set.