### PR TITLE
adapt the PA2021PE parameters to use the new 2020Q4 data

### DIFF
--- a/parameter_files/ProjectParameters_PA2021PE.yml
+++ b/parameter_files/ProjectParameters_PA2021PE.yml
@@ -1,5 +1,8 @@
 default:
 
+    paths:
+        data_location_ext: ../pacta-data/2020Q4/
+
     reporting:
         project_report_name: Peru
         display_currency: USD
@@ -7,7 +10,7 @@ default:
 
     parameters:
         timestamp: 2020Q4
-        dataprep_timestamp: 2020Q4_05172021_2020
+        dataprep_timestamp: 2020Q4_transitionmonitor
         start_year: 2021
         horizon_year: 5
         select_scenario: WEO2019_SDS


### PR DESCRIPTION
FYI @NayraHerrera @catarinabrg @daisy-pacheco @AlexAxthelm 

COP project parameter files need to use this new parameter to access the 2020Q4 data, as is the case with the [Norway/PA2021NO parameter file](https://github.com/2DegreesInvesting/PACTA_analysis/blob/master/parameter_files/ProjectParameters_PA2021NO.yml)

```yaml
    paths:
        data_location_ext: ../pacta-data/2020Q4/
```