### PR TITLE
enable reading `holdings_date` from portfolio parameters

### DIFF
--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -46,9 +46,7 @@ set_col_types <- function(grouping_variables, fixed_col_types) {
 set_project_parameters <- function(file_path){
   cfg <- config::get(file = file_path)
 
-  if (!is.null(cfg$paths$data_location_ext)) {
-    data_location_ext <<- cfg$paths$data_location_ext
-  }
+  proj_data_location_ext <<- cfg$paths$data_location_ext
 
   project_report_name <<- cfg$reporting$project_report_name
   display_currency <<- cfg$reporting$display_currency
@@ -260,7 +258,16 @@ set_analysis_inputs_path <- function(twodii_internal, data_location_ext, datapre
     analysis_inputs_path <- r2dii.utils::path_dropbox_2dii("PortCheck", "00_Data", "07_AnalysisInputs", dataprep_ref)
     analysis_inputs_path <- file.path(analysis_inputs_path)
   } else {
-    analysis_inputs_path <- data_location_ext
+    # project level setting takes precedence, portfolio level second, else what
+    # set_webtool_paths() sets for data_location_ext
+    if (!is.null(proj_data_location_ext)) {
+      analysis_inputs_path <- proj_data_location_ext
+    } else if (!is.null(port_holdings_date)) {
+      analysis_inputs_path <- file.path("..", "pacta-data", port_holdings_date)
+    } else {
+      analysis_inputs_path <- data_location_ext
+    }
+
   }
 
   return(analysis_inputs_path)

--- a/0_web_functions.R
+++ b/0_web_functions.R
@@ -97,6 +97,7 @@ set_portfolio_parameters <- function(file_path) {
   language_select <<- cfg$parameters$language
   user_id <<- cfg$parameters$user_id
   project_code <<- cfg$parameters$project_code
+  port_holdings_date <<- cfg$parameters$holdings_date
 }
 
 add_naming_to_portfolio <- function(portfolio_raw) {


### PR DESCRIPTION
enable reading `holdings_date` from portfolio parameters and setting `data_location_ext` with proper precedence

this will allow setting `data_location_ext` with the following precedence:
1. project parameters
2. portfolio parameters
3. web parameters (default)

I renamed the imported project parameter from `data_location_ext` to `proj_data_location_ext`. Originally, I allowed `set_project_parameters()` to just overwrite the `data_location_ext` set by  `set_web_parameters()` by default. Now instead the project data location parameter is read in as a unique variable (or as `NULL`) so that `set_analysis_inputs_path()` can properly set `analysis_inputs_path` based on the precedence above.

concerns I still have:
1. my understanding of this is that during the analysis `analysis_inputs_path` should always be used to find the input data, though some code may look/read in from `data_location_ext` (this also potentially applies to stress testing @jacobvjk @MirijaHa)... this is not a new problem, but now that we've created 2 ways of setting `analysis_inputs_path` to something different than what `data_location_ext` is set to by default, it kind of ups the ante for things to go wrong
2. I did not want to change the function signature of `set_analysis_inputs_path()`, and then be forced to change every call to it in every repo, so... `set_analysis_inputs_path()` now relies on variables `proj_data_location_ext` and `port_holdings_date` being available in a parent or global environment.