### PR TITLE
remove all the confusing extra example files

### DIFF
--- a/working_dir/10_Parameter_File/0_Indices_Input_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/0_Indices_Input_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: test_portfolio
-        investor_name_in: Test
-

--- a/working_dir/10_Parameter_File/BondsTest_Input_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/BondsTest_Input_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: test_portfolio
-        investor_name_in: Test
-

--- a/working_dir/10_Parameter_File/Portfolio2_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/Portfolio2_PortfolioParameters.yml
@@ -1,8 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Portfolio 2
-        investor_name_in: Sample Investor
-        peergroup: pensionfund
-        user_id: 100
-        language: EN
-

--- a/working_dir/10_Parameter_File/Portfolio3_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/Portfolio3_PortfolioParameters.yml
@@ -1,6 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Portfolio 3
-        investor_name_in: Sample Investor
-        
-

--- a/working_dir/10_Parameter_File/TestPortfolio_empty_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/TestPortfolio_empty_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Sample Portfolio
-        investor_name_in: Sample Investor
-

--- a/working_dir/10_Parameter_File/TestPortfolio_group_vars_NA_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/TestPortfolio_group_vars_NA_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Sample Portfolio
-        investor_name_in: Sample Investor
-

--- a/working_dir/10_Parameter_File/TestPortfolio_missing_cols_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/TestPortfolio_missing_cols_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Sample Portfolio
-        investor_name_in: Sample Investor
-

--- a/working_dir/10_Parameter_File/TestPortfolio_single_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/TestPortfolio_single_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: test_portfolio
-        investor_name_in: Test
-

--- a/working_dir/10_Parameter_File/TestPortfolio_tsv_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/TestPortfolio_tsv_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Sample Portfolio
-        investor_name_in: Sample Investor
-

--- a/working_dir/10_Parameter_File/TestPortfolio_wrong_var_class_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/TestPortfolio_wrong_var_class_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Sample Portfolio
-        investor_name_in: Sample Investor
-

--- a/working_dir/10_Parameter_File/TestPortfolio_wrong_var_name_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/TestPortfolio_wrong_var_name_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: Sample Portfolio
-        investor_name_in: Sample Investor
-

--- a/working_dir/10_Parameter_File/WebParameters.yml
+++ b/working_dir/10_Parameter_File/WebParameters.yml
@@ -1,9 +1,0 @@
-default:
-    paths:
-        project_location_ext: /bound/web_folders/
-        data_location_ext: /pacta-data/2019Q4/
-    parameters:
-        project_name: working_dir
-        twodii_internal: FALSE
-        new_data: FALSE
-

--- a/working_dir/10_Parameter_File/liechtenstein_p2020_rerun_Input_PortfolioParameters.yml
+++ b/working_dir/10_Parameter_File/liechtenstein_p2020_rerun_Input_PortfolioParameters.yml
@@ -1,5 +1,0 @@
-default:
-    parameters:
-        portfolio_name_in: test_portfolio
-        investor_name_in: Test
-


### PR DESCRIPTION
All the extra example files under `working_dir/` add more confusion than any help. This removes all of them but the 2 files that are essential for the "default" example to work (based on `TestPortfolio_Input` being explicitly [set as the default here](https://github.com/2DegreesInvesting/PACTA_analysis/blob/0936c1d71462443179a875156b587b7fba795b0a/web_tool_script_1.R#L12) and in the other web tool scripts). The existing [.gitignore](https://github.com/2DegreesInvesting/PACTA_analysis/blob/0936c1d71462443179a875156b587b7fba795b0a/.gitignore#L36-L43) file already ignores any new files that might be added to those directories so they cannot be committed by accident. The directory structure underneath `working_dir/` is required, so those sub-directories are kept/protected by containing a `.gitkeep.txt` file, like[ this one](https://github.com/2DegreesInvesting/PACTA_analysis/blob/master/working_dir/00_Log_Files/.gitkeep.txt). The only two files left then under `working_dir/` are those that are essential for PACTA to run:
[working_dir/10_Parameter_File/TestPortfolio_Input_PortfolioParameters.yml](https://github.com/2DegreesInvesting/PACTA_analysis/blob/master/working_dir/10_Parameter_File/TestPortfolio_Input_PortfolioParameters.yml)
[working_dir/20_Raw_Inputs/TestPortfolio_Input.csv](https://github.com/2DegreesInvesting/PACTA_analysis/blob/master/working_dir/20_Raw_Inputs/TestPortfolio_Input.csv)