### PR TITLE
Remove global env variables from `tdm_utility_functions`

### DIFF
--- a/R/tdm_utility_functions.R
+++ b/R/tdm_utility_functions.R
@@ -6,15 +6,15 @@ analysis_inputs_with_tdm_scenarios <- function() {
   c("../pacta-data/2020Q4")
 }
 
-data_includes_tdm_scenarios <- function() {
+data_includes_tdm_scenarios <- function(analysis_inputs_path) {
   analysis_inputs_path %in% analysis_inputs_with_tdm_scenarios()
 }
 
-tdm_conditions_met <- function() {
-  project_code == "GENERAL" && data_includes_tdm_scenarios()
+tdm_conditions_met <- function(analysis_inputs_path) {
+  project_code == "GENERAL" && data_includes_tdm_scenarios(analysis_inputs_path)
 }
 
-determine_tdm_variables <- function() {
+determine_tdm_variables <- function(start_year) {
   list(
     t0 = start_year,
     delta_t1 = 5,

--- a/R/tdm_utility_functions.R
+++ b/R/tdm_utility_functions.R
@@ -10,11 +10,11 @@ data_includes_tdm_scenarios <- function() {
   analysis_inputs_path %in% analysis_inputs_with_tdm_scenarios()
 }
 
-tdm_conditions_met <- function () {
+tdm_conditions_met <- function() {
   project_code == "GENERAL" && data_includes_tdm_scenarios()
 }
 
-determine_tdm_variables <- function () {
+determine_tdm_variables <- function() {
   list(
     t0 = start_year,
     delta_t1 = 5,

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -112,8 +112,8 @@ if (file.exists(equity_input_file)) {
     }
     if (data_check(port_all_eq)) {
 
-      if (tdm_conditions_met()) {
-        tdm_vars <- determine_tdm_variables()
+      if (tdm_conditions_met(analysis_inputs_path)) {
+        tdm_vars <- determine_tdm_variables(start_year)
 
         equity_tdm <-
           calculate_tdm(
@@ -129,7 +129,7 @@ if (file.exists(equity_input_file)) {
       }
 
       # filter out scenarios used only for TDM, if they exist
-      if (data_includes_tdm_scenarios()) {
+      if (data_includes_tdm_scenarios(analysis_inputs_path)) {
         port_all_eq <- filter(port_all_eq, ! scenario %in% tdm_scenarios())
       }
 
@@ -221,8 +221,8 @@ if (file.exists(bonds_inputs_file)) {
       write_rds(company_all_cb, file.path(pf_file_results_path, "Bonds_results_company.rda"))
     }
     if (data_check(port_all_cb)) {
-      if (tdm_conditions_met()) {
-        tdm_vars <- determine_tdm_variables()
+      if (tdm_conditions_met(analysis_inputs_path)) {
+        tdm_vars <- determine_tdm_variables(start_year)
 
         bonds_tdm <-
           calculate_tdm(
@@ -238,7 +238,7 @@ if (file.exists(bonds_inputs_file)) {
       }
 
       # filter out scenarios used only for TDM, if they exist
-      if (data_includes_tdm_scenarios()) {
+      if (data_includes_tdm_scenarios(analysis_inputs_path)) {
         port_all_cb <- filter(port_all_cb, ! scenario %in% tdm_scenarios())
       }
 


### PR DESCRIPTION
I noticed (when running R CMD Check) that some of the functions in `tdm_utility_functions.R` depend on variables in the global environment (ie. variables that are not explicitly defined as function arguments). 

I know this is how a lot of the legacy PACTA code runs, but i think we should be prudent that all new code doesn't rely on this. 