### PR TITLE
Always evaluate tdm conditions as unmet

### DIFF
--- a/R/tdm_utility_functions.R
+++ b/R/tdm_utility_functions.R
@@ -12,6 +12,8 @@ data_includes_tdm_scenarios <- function() {
 
 tdm_conditions_met <- function () {
   project_code == "GENERAL" && data_includes_tdm_scenarios()
+  # TODO: remove this when we're ready to actually roll out TDM to users
+  return(FALSE)
 }
 
 determine_tdm_variables <- function () {


### PR DESCRIPTION
this is a temporary workaround to allow a new docker image to be built
and deployed, without rolling out TDM to users prematurely.