### PR TITLE
quit wiith 0 status code, rather than error

### DIFF
--- a/R/user_error_checks.R
+++ b/R/user_error_checks.R
@@ -50,7 +50,11 @@ check_grouped_portfolio_years <- function(
       description = desc,
       immediate = TRUE
     )
-    stop("port_holdings_date contains multiple distinct values", call. = FALSE)
+    # using message and quit, rather than stop(), because server silently
+    # fails if docker container exits with anything other than a 0 status
+    # code
+    message("port_holdings_date contains multiple distinct values")
+    quit(status = 0L)
   }
   return(invisible(port_holdings_date))
 }

--- a/R/user_error_checks.R
+++ b/R/user_error_checks.R
@@ -54,7 +54,7 @@ check_grouped_portfolio_years <- function(
     # fails if docker container exits with anything other than a 0 status
     # code
     message("port_holdings_date contains multiple distinct values")
-    quit(status = 0L)
+    quit(save = "no", status = 0L, runLast = FALSE)
   }
   return(invisible(port_holdings_date))
 }


### PR DESCRIPTION
the Constructiva server fails quietly (infinite spinner) if the docker
container errors, but it will show the index.html if it returns status
code `0`. So for user-correctable errors, we'll do that, and give them
an informative message.