### PR TITLE
add build version as ENV var inside image and display it when running

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -157,7 +157,7 @@ expect_no_message <- function(object, regexp = NA, ...) {
   testthat::expect_message(object = object, regexp = regexp, ...)
 }
 
-get_build_version <- function(env_var = "$build_version") {
-  build_version <- system2("echo", args = env_var, stdout = TRUE)
+get_build_version <- function(env_var = "build_version") {
+  build_version <- Sys.getenv(env_var)
   ifelse(nzchar(build_version), paste0("v", build_version), NA_character_)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -156,3 +156,8 @@ mark_end <- function() {
 expect_no_message <- function(object, regexp = NA, ...) {
   testthat::expect_message(object = object, regexp = regexp, ...)
 }
+
+get_build_version <- function(env_var = "$build_version") {
+  build_version <- system2("echo", args = env_var, stdout = TRUE)
+  ifelse(nzchar(build_version), paste0("v", build_version), NA_character_)
+}

--- a/transitionmonitor_docker/Dockerfile
+++ b/transitionmonitor_docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM 2dii/r-packages@sha256:2e99aaf36141cade6bc6f51023dfdf6dba87c464ee17a062207a37707553d69a
 
+ENV build_version=$image_tag
+
 COPY PACTA_analysis /bound
 COPY create_interactive_report /create_interactive_report
 COPY pacta-data /pacta-data

--- a/transitionmonitor_docker/build_with_tag.sh
+++ b/transitionmonitor_docker/build_with_tag.sh
@@ -124,7 +124,7 @@ done
 
 # Copy Dockerfile alongside pacta siblings and build the image
 cp "${dir_start}/Dockerfile" "$dir_temp"
-docker build --platform linux/x86_64 --tag 2dii_pacta:"$tag" --tag 2dii_pacta:latest .
+docker build --platform linux/x86_64 --build-arg image_tag="$tag" --tag 2dii_pacta:"$tag" --tag 2dii_pacta:latest .
 echo
 
 cd $dir_start

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -1,10 +1,10 @@
-build_version <- system2("echo", args = "$build_version", stdout = TRUE)
-if (nchar(build_version) > 0) build_version <- paste0(" - running in Docker build v", build_version)
-
-cli::cli_h1(paste0("web_tool_script_1.R", build_version))
+cli::cli_h1("web_tool_script_1.R")
 
 devtools::load_all(quiet = TRUE)
 use_r_packages()
+
+build_version <- get_build_version()
+if (!is.na(build_version)) cli::cli_h1(paste("Docker build", build_version))
 
 source("0_portfolio_input_check_functions.R")
 source("0_global_functions.R")

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -1,4 +1,7 @@
-cli::cli_h1("web_tool_script_1.R")
+build_version <- system2("echo", args = "$build_version", stdout = TRUE)
+if (nchar(build_version) > 0) build_version <- paste0(" - running in Docker build v", build_version)
+
+cli::cli_h1(paste0("web_tool_script_1.R", build_version))
 
 devtools::load_all(quiet = TRUE)
 use_r_packages()

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -1,10 +1,10 @@
-build_version <- system2("echo", args = "$build_version", stdout = TRUE)
-if (nchar(build_version) > 0) build_version <- paste0(" - running in Docker build v", build_version)
-
-cli::cli_h1(paste0("web_tool_script_2.R", build_version))
+cli::cli_h1("web_tool_script_2.R")
 
 devtools::load_all(quiet = TRUE)
 use_r_packages()
+
+build_version <- get_build_version()
+if (!is.na(build_version)) cli::cli_h1(paste("Docker build", build_version))
 
 #########################################################################
 # START RUN ANALYIS

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -1,4 +1,7 @@
-cli::cli_h1("web_tool_script_2.R")
+build_version <- system2("echo", args = "$build_version", stdout = TRUE)
+if (nchar(build_version) > 0) build_version <- paste0(" - running in Docker build v", build_version)
+
+cli::cli_h1(paste0("web_tool_script_2.R", build_version))
 
 devtools::load_all(quiet = TRUE)
 use_r_packages()

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -1,10 +1,10 @@
-build_version <- system2("echo", args = "$build_version", stdout = TRUE)
-if (nchar(build_version) > 0) build_version <- paste0(" - running in Docker build v", build_version)
-
-cli::cli_h1(paste0("web_tool_script_3.R", build_version))
+cli::cli_h1("web_tool_script_3.R")
 
 devtools::load_all(quiet = TRUE)
 use_r_packages()
+
+build_version <- get_build_version()
+if (!is.na(build_version)) cli::cli_h1(paste("Docker build", build_version))
 
 source("0_global_functions.R")
 source("0_web_functions.R")

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -1,4 +1,7 @@
-cli::cli_h1("web_tool_script_3.R")
+build_version <- system2("echo", args = "$build_version", stdout = TRUE)
+if (nchar(build_version) > 0) build_version <- paste0(" - running in Docker build v", build_version)
+
+cli::cli_h1(paste0("web_tool_script_3.R", build_version))
 
 devtools::load_all(quiet = TRUE)
 use_r_packages()


### PR DESCRIPTION
prototype for burning the Docker build version tag into the image as an environment variable when it is built, and then printing that, if it's available, along with the message that shows what script is running.

@AlexAxthelm you know what this is for 😬 