### PR TITLE
declare image_tag argument in Dockerfile

### DIFF
--- a/transitionmonitor_docker/Dockerfile
+++ b/transitionmonitor_docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM 2dii/r-packages@sha256:2e99aaf36141cade6bc6f51023dfdf6dba87c464ee17a062207a37707553d69a
 
+ARG image_tag
 ENV build_version=$image_tag
 
 COPY PACTA_analysis /bound


### PR DESCRIPTION
Apparently you have to declare the build ARG for it to be picked up and available from the `--build-arg image_tag="$tag"` `docker build` option? Honestly I don't know much about this stuff, but this seems to be working as expected now. Easy way to test immediately after building an image is with `docker inspect 2dii_pacta:[TAG_NUMBER]` and check for something like this in the `Config` section
```json
"Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "build_version=0.3.0"
            ]
```