### PR TITLE
use the portfolio ID not the name for output dir

### DIFF
--- a/R/user_error_infrastructure.R
+++ b/R/user_error_infrastructure.R
@@ -1,7 +1,7 @@
 prepare_error_report <- function(
   report_template = file.path("inst", "rmd", "user_errors.Rmd"),
   error_file = file.path(html_directory, "user_errors.json"),
-  html_directory = file.path(outputs_path, portfolio_name, "report"),
+  html_directory = file.path(outputs_path, portfolio_name_ref_all, "report"),
   file_name = "index.html"
   ) {
   if (file.exists(error_file)) {
@@ -26,7 +26,7 @@ log_user_errors <- function(
   description = "",
   error_file = file.path(
     outputs_path,
-    portfolio_name,
+    portfolio_name_ref_all,
     "report",
     "user_errors.json"
     ),


### PR DESCRIPTION
If I understand Simon correctly, they expect the output directories names to match the portfolio's unique ID on the server, rather than the human readable portfolio name given by the user. This portfolio ID is what is passed as the single command line argument when running the web tool scripts, and it is saved in the object named `portfolio_name_ref_all`. In other contexts (not on the server), it is usually assumed that the portfolio ID and the portfolio name are the same, so this should not change/effect other use cases, e.g. one would expect to have...

in `working_dir/10_Parameter_File/[PORTFOLIO_NAME]_PortfolioParameters.yml`
```yml
default:
    parameters:
        portfolio_name: [PORTFOLIO_NAME]
        investor_name: Test
        peer_group: pensionfund
        language: EN
        project_code: GENERAL
        holdings_date: 2020Q4
```

a portfolio CSV named: `working_dir/20_Raw_Inputs/[PORTFOLIO_NAME].csv`

in R, objects `portfolio_name_ref_all` and `portfolio_name`, both with the value `[PORTFOLIO_NAME]`

and the output would be in `working_dir/50_Outputs/[PORTFOLIO_NAME]/report/index.html`