### PR TITLE
catch errors in stress test and log a message but continue

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -45,12 +45,12 @@ options("ST_DATA_PATH" = stress_test_data_location)
 # run 2dii stress test
 tryCatch(
   source(file.path(stress_test_path, "web_tool_stress_test.R")),
-  error = function(e) simpleError("an error in web_tool_stress_test.R occurred")
+  error = function(e) { msg <- "an error in web_tool_stress_test.R occurred"; print(msg); log_user_errors(msg) }
 )
 # run stress test with external scenarios (IPR)
 tryCatch(
   source(file.path(stress_test_path, "web_tool_external_stress_test.R")),
-  error = function(e) simpleError("an error in web_tool_external_stress_test.R occurred")
+  error = function(e) { msg <- "an error in web_tool_external_stress_test.R occurred"; print(msg); log_user_errors(msg) }
 )
 
 

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -43,9 +43,15 @@ invisible(set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(po
 # set environment variable for stress test data path
 options("ST_DATA_PATH" = stress_test_data_location)
 # run 2dii stress test
-source(file.path(stress_test_path, "web_tool_stress_test.R"))
+tryCatch(
+  source(file.path(stress_test_path, "web_tool_stress_test.R")),
+  error = function(e) simpleError("an error in web_tool_stress_test.R occurred")
+)
 # run stress test with external scenarios (IPR)
-source(file.path(stress_test_path, "web_tool_external_stress_test.R"))
+tryCatch(
+  source(file.path(stress_test_path, "web_tool_external_stress_test.R")),
+  error = function(e) simpleError("an error in web_tool_external_stress_test.R occurred")
+)
 
 
 # create interactive report -----------------------------------------------


### PR DESCRIPTION
Full stop errors in the stress testing leads to The Infinite Spinning Cog™ on the platform, which is not a good user experience, and is especially difficult to debug given the current constraints we have with access to logs and notifications of problems. It also seems to be one of the more common problems that we face.

This PR wraps the sourcing of the stress test code in a `tryCatch()` so that if/when an error code occurs, the report generation will continue and not cause a full stop error, which will lead to the user being able to view their report, though some of the stress testing charts/data may not be available.

Ideally, this PR should be paired with a PR in [create_interactive_report](https://github.com/2DegreesInvesting/create_interactive_report) that would notify the user if there is no data available to plot any of the stress testing charts with an informative message that would ideally prompt the user to let us know that something went wrong with their stress testing section. I imagine such a feature could work very similar to what was implemented in [this PR](https://github.com/2DegreesInvesting/create_interactive_report/pull/291). @MonikaFu 