### PR TITLE
Remove `{rstudioapi}` dependency

### DIFF
--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -32,11 +32,7 @@ is_blank_na <- function(x) {
 }
 
 set_location <- function() {
-  if (require(rstudioapi) && rstudioapi::isAvailable()) {
-    working_location <- dirname(rstudioapi::getActiveDocumentContext()$path)
-  } else {
-    working_location <- getwd()
-  }
+  working_location <- getwd()
 
   working_location <- paste0(working_location, "/")
 
@@ -262,11 +258,7 @@ set_project_paths <- function(project_name, twodii_internal, project_location_ex
 }
 
 set_git_path <- function() {
-  if (require(rstudioapi) && rstudioapi::isAvailable()) {
-    git_path <- dirname(rstudioapi::getActiveDocumentContext()$path)
-  } else {
-    git_path <- getwd()
-  }
+  git_path <- getwd()
 
   git_path <- gsub("?", "", git_path)
   git_path <- paste0(git_path, "/")

--- a/0_global_functions.R
+++ b/0_global_functions.R
@@ -32,7 +32,7 @@ is_blank_na <- function(x) {
 }
 
 set_location <- function() {
-  if (rstudioapi::isAvailable()) {
+  if (require(rstudioapi) && rstudioapi::isAvailable()) {
     working_location <- dirname(rstudioapi::getActiveDocumentContext()$path)
   } else {
     working_location <- getwd()
@@ -262,7 +262,7 @@ set_project_paths <- function(project_name, twodii_internal, project_location_ex
 }
 
 set_git_path <- function() {
-  if (rstudioapi::isAvailable()) {
+  if (require(rstudioapi) && rstudioapi::isAvailable()) {
     git_path <- dirname(rstudioapi::getActiveDocumentContext()$path)
   } else {
     git_path <- getwd()

--- a/1_portfolio_check_initialisation.R
+++ b/1_portfolio_check_initialisation.R
@@ -9,7 +9,7 @@ use_r_packages()
 ## Project Initialisation
 rm(list = ls())
 
-if (rstudioapi::isAvailable()) {
+if (require(rstudioapi) && rstudioapi::isAvailable()) {
   working_location <- dirname(rstudioapi::getActiveDocumentContext()$path)
 } else {
   working_location <- getwd()

--- a/1_portfolio_check_initialisation.R
+++ b/1_portfolio_check_initialisation.R
@@ -9,11 +9,7 @@ use_r_packages()
 ## Project Initialisation
 rm(list = ls())
 
-if (require(rstudioapi) && rstudioapi::isAvailable()) {
-  working_location <- dirname(rstudioapi::getActiveDocumentContext()$path)
-} else {
-  working_location <- getwd()
-}
+working_location <- getwd()
 
 working_location <- paste0(working_location, "/")
 setwd(working_location)

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,7 +32,6 @@ required_packages_vec <- function() {
     "readxl",
     "rlang",
     "rmarkdown",
-    "rstudioapi",
     "scales",
     "stringr",
     "testthat",


### PR DESCRIPTION
`{rstudioapi}` is only used in a few locations, and is only used if `rstudioapi::isAvailable()` is `TRUE`, so it is not a hard dependency and therefore should not be forced to be included. Starting these tests with `require(rstudioapi) && ` should prevent them from running unless `{rstudioapi}` is available.

https://github.com/2DegreesInvesting/PACTA_analysis/blob/11ea54588f9b618c6f1b09c5f712146f5f0628f3/1_portfolio_check_initialisation.R#L12-L16

https://github.com/2DegreesInvesting/PACTA_analysis/blob/21187adf25697c10caaf3b9a517f2607dcb7594a/0_global_functions.R#L34-L39

https://github.com/2DegreesInvesting/PACTA_analysis/blob/21187adf25697c10caaf3b9a517f2607dcb7594a/0_global_functions.R#L264-L269

related to #137 