### PR TITLE
depend on individual pkgs rather than all of `{tidyverse}`

### DIFF
--- a/.github/workflows/testthat-test_local.yml
+++ b/.github/workflows/testthat-test_local.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         shell: Rscript {0}
         run: |
-          install.packages(c("assertthat", "cli", "config", "conflicted", "countrycode", "devtools", "DT", "fs", "fst", "glue", "here", "janitor", "knitr", "plyr", "r2dii.utils", "remotes", "renv", "rmarkdown", "snakecase", "testthat", "tidyverse", "withr", "yaml", "zoo"))
+          install.packages(c("assertthat", "cli", "config", "conflicted", "countrycode", "devtools", "dplyr", "DT", "fs", "fst", "glue", "here", "janitor", "knitr", "plyr", "purrr", "r2dii.utils", "readr", "remotes", "renv", "rmarkdown", "snakecase", "testthat", "tibble", "tidyr", "withr", "yaml", "zoo"))
           devtools::install_github("2DegreesInvesting/r2dii.utils")
 
       - name: Install system dependencies

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Ensure you have the required libraries installed on your computer.
 Further, the evaluation will require a bunch of package. It is recommanded install the package during the first run of the code. (assess approx. 30 minutes for the installation process during the first usage of the code).
 
 Necessary packages are: 
-assertthat, config, conflicted, devtools, DT, fs, fst, glue, here, janitor, 
-knitr, plyr, renv, rmarkdown, snakecase, testthat, tidyverse, 
-withr, yaml
+assertthat, config, conflicted, devtools, dplyr, DT, fs, fst, glue, here, 
+janitor, knitr, plyr, purrr, readr, renv, rmarkdown, snakecase, testthat, 
+tibble, tidyr, withr, yaml
     
 **For report generation:**
 
@@ -47,7 +47,7 @@ MiKTeX - a distribution of the LaTeX typesetting system ; includes TeXworks
 preferably version 2.9
 
 Further R packages needed:
-grid, ggplot2, ggthemes, dplyr, reshape2, gridExtra, scales, stringr, extrafont, tidyr, knitr, RColorBrewer, matrixStats, rworldmap, ggmap, cowplot, ggrepel, readxl, tidyverse, ggforce, sitools , countrycode
+grid, ggplot2, ggthemes, reshape2, gridExtra, scales, stringr, extrafont, knitr, RColorBrewer, matrixStats, rworldmap, ggmap, cowplot, ggrepel, readxl, ggforce, sitools , countrycode
 
 ## How to "download" the code
 

--- a/indices_benchmarks/combine_indices.R
+++ b/indices_benchmarks/combine_indices.R
@@ -12,7 +12,9 @@ holdings_date <- "2020Q4"
 
 # -------------------------------------------------------------------------
 
-library(tidyverse)
+library(readr)
+library(dplyr)
+library(purrr)
 library(fs)
 library(cli)
 library(yaml)

--- a/pacta_data_qa.Rmd
+++ b/pacta_data_qa.Rmd
@@ -18,7 +18,7 @@ output:
 ```{r setup, include=FALSE}
 # set echo = TRUE, for more insight to the code printed in the output
 knitr::opts_chunk$set(echo = FALSE)
-library(tidyverse)
+library(dplyr)
 library(DT)
 
 project_code <- params$project_code


### PR DESCRIPTION
Remove dependency on all of `{tidyverse}` and instead depend on and load/install only the individual underlying packages actually required.