### PR TITLE
don't load `{config}`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -13,7 +13,6 @@ setup_project <- function() {
 required_packages_vec <- function() {
   c(
     "bookdown",
-    "config",
     "conflicted",
     "countrycode",
     "devtools",


### PR DESCRIPTION
Because `{config}` has two exported function names that override important and frequently used `{base}` commands (`get()` and `merge()`), it is preferable to never load `{config}` and rather always use its functions namespaced, e.g. `config::get()` and `config::merge()`.

I have verified that in the existing code, everywhere `config::get()` is used, it is already namespaced. `config::merge()` does not appear to be used at all in this repo. `base::get()` is used a few times in this repo and it is also always namespaced currently. `base::merge()` does not appear to be used anywhere currently.