### PR TITLE
remove `{conflicted}` dependency

### DIFF
--- a/.github/workflows/testthat-test_local.yml
+++ b/.github/workflows/testthat-test_local.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         shell: Rscript {0}
-        run: install.packages(c("cli", "config", "conflicted", "countrycode", "devtools", "dplyr", "fs", "fst", "glue", "here", "janitor", "knitr", "purrr", "readr", "remotes", "rmarkdown", "testthat", "tibble", "tidyr", "withr", "yaml", "zoo"))
+        run: install.packages(c("cli", "config", "countrycode", "devtools", "dplyr", "fs", "fst", "glue", "here", "janitor", "knitr", "purrr", "readr", "remotes", "rmarkdown", "testthat", "tibble", "tidyr", "withr", "yaml", "zoo"))
 
       - name: Install system dependencies
         if: runner.os == 'Linux'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Depends:
     R (>= 3.5)
 Imports: 
     config,
-    conflicted,
     dplyr,
     fs,
     fst,

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,6 @@ required_packages_vec <- function() {
   c(
     "bookdown",
     "config",
-    "conflicted",
     "countrycode",
     "devtools",
     "dplyr",
@@ -47,18 +46,6 @@ use_r_packages <- function() {
   suppressPackageStartupMessages({
     for (pkg in required_packages_vec()) { library(pkg, character.only = TRUE) }
   })
-
-  resolve_conflicts()
-}
-
-resolve_conflicts <- function() {
-  conflicted::conflict_prefer("filter", "dplyr", quiet = TRUE)
-  conflicted::conflict_prefer("lag", "dplyr", quiet = TRUE)
-  conflicted::conflict_prefer("mutate", "dplyr", quiet = TRUE)
-  conflicted::conflict_prefer("here", "here", quiet = TRUE)
-  conflicted::conflict_prefer("rename", "dplyr", quiet = TRUE)
-  conflicted::conflict_prefer("summarise", "dplyr", quiet = TRUE)
-  conflicted::conflict_prefer("arrange", "dplyr", quiet = TRUE)
 }
 
 #' @examples

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Ensure you have the required libraries installed on your computer.
 Further, the evaluation will require a bunch of package. It is recommanded install the package during the first run of the code. (assess approx. 30 minutes for the installation process during the first usage of the code).
 
 Necessary packages are: 
-config, conflicted, devtools, dplyr, fs, fst, glue, here, janitor, knitr, plyr, 
-purrr, readr, renv, rmarkdown, snakecase, testthat, tibble, tidyr, withr, yaml
+config, devtools, dplyr, fs, fst, glue, here, janitor, knitr, plyr, purrr, 
+readr, renv, rmarkdown, snakecase, testthat, tibble, tidyr, withr, yaml
     
 **For report generation:**
 


### PR DESCRIPTION
The purpose/use of `{conflicted}` appears to be only here...

Presumably, the intention is to address the conflict between `dplyr::filter` and `dplyr::lag` and the `{stats}` version of those functions. Since `{stats}` always loads with base R before any other packages are explicitly loaded, I think it's extremely common that when a user loads `{dplyr}`, which itself is extremely common, they understand that `dplyr::filter` and `dplyr::lag` are what will be used. I have verified that there are no current usages of `stats::filter` or `stats::lag`, and frankly I can't imagine why there ever will/would be.

The rest of the functions here, `dplyr::mutate`, `dplyr::here`, `dplyr::rename`, `dplyr::summarise`, and `dplyr::arrange`, are presumably here to avoid a conflict with the `{plyr}` versions of theses functions. I have verified that none of the `{plyr}` versions of those functions are currently in use... the only existing usage of `{plyr}` is two `plyr::mapvalues()`commands, which have already been replaced with `dplyr::recode()` in #562. `{plyr}` itself is on it's way out too with #562, so once that has landed, this usage of `{conflicted}` will also be completely irrelevant.
