### PR TITLE
remove `{countrycode}`

### DIFF
--- a/.github/workflows/testthat-test_local.yml
+++ b/.github/workflows/testthat-test_local.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         shell: Rscript {0}
-        run: install.packages(c("cli", "config", "conflicted", "countrycode", "devtools", "dplyr", "fs", "fst", "glue", "here", "janitor", "knitr", "purrr", "readr", "remotes", "rmarkdown", "testthat", "tibble", "tidyr", "withr", "yaml", "zoo"))
+        run: install.packages(c("cli", "config", "conflicted", "devtools", "dplyr", "fs", "fst", "glue", "here", "janitor", "knitr", "purrr", "readr", "remotes", "rmarkdown", "testthat", "tibble", "tidyr", "withr", "yaml", "zoo"))
 
       - name: Install system dependencies
         if: runner.os == 'Linux'

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,6 @@ required_packages_vec <- function() {
     "bookdown",
     "config",
     "conflicted",
-    "countrycode",
     "devtools",
     "dplyr",
     "fs",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ MiKTeX - a distribution of the LaTeX typesetting system ; includes TeXworks
 preferably version 2.9
 
 Further R packages needed:
-grid, ggplot2, ggthemes, reshape2, gridExtra, scales, stringr, extrafont, knitr, RColorBrewer, matrixStats, rworldmap, ggmap, cowplot, ggrepel, readxl, ggforce, sitools , countrycode
+grid, ggplot2, ggthemes, reshape2, gridExtra, scales, stringr, extrafont, knitr, RColorBrewer, matrixStats, rworldmap, ggmap, cowplot, ggrepel, readxl, ggforce, sitools
 
 ## How to "download" the code
 


### PR DESCRIPTION
`{countrycode}` does not appear to be used anywhere in this repo, so don't load it or list it as a dependency (it is currently a dependency for the transitionmonitor Docker image)