### PR TITLE
consolidate console messages

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -141,3 +141,8 @@ get_build_version <- function(env_var = "build_version") {
   build_version <- Sys.getenv(env_var)
   ifelse(nzchar(build_version), paste0("v", build_version), NA_character_)
 }
+
+get_build_version_msg <- function() {
+  build_version <- get_build_version()
+  ifelse(is.na(build_version), "", paste0(" (Docker build ", build_version, ")"))
+}

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -1,10 +1,7 @@
-cli::cli_h1("web_tool_script_1.R")
-
 devtools::load_all(quiet = TRUE)
 use_r_packages()
 
-build_version <- get_build_version()
-if (!is.na(build_version)) cli::cli_h1(paste("Docker build", build_version))
+cli::cli_h1("web_tool_script_1.R{get_build_version_msg()}")
 
 source("0_portfolio_input_check_functions.R")
 source("0_global_functions.R")

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -1,10 +1,7 @@
-cli::cli_h1("web_tool_script_2.R")
-
 devtools::load_all(quiet = TRUE)
 use_r_packages()
 
-build_version <- get_build_version()
-if (!is.na(build_version)) cli::cli_h1(paste("Docker build", build_version))
+cli::cli_h1("web_tool_script_2.R{get_build_version_msg()}")
 
 #########################################################################
 # START RUN ANALYIS

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -1,10 +1,7 @@
-cli::cli_h1("web_tool_script_3.R")
-
 devtools::load_all(quiet = TRUE)
 use_r_packages()
 
-build_version <- get_build_version()
-if (!is.na(build_version)) cli::cli_h1(paste("Docker build", build_version))
+cli::cli_h1("web_tool_script_3.R{get_build_version_msg()}")
 
 source("0_global_functions.R")
 source("0_web_functions.R")


### PR DESCRIPTION
Currently, if there's a `build_version` system environment variable set, the console will print this...
```
── web_tool_script_1.R ────────────────────────────────────────────────────────────────

── Docker build v0.4.5 ────────────────────────────────────────────────────────────────
```

This PR consolidates those messages into one like this...
```
── web_tool_script_1.R (Docker build v0.4.5) ──────────────────────────────────────────
```

If there is no `build_version` system environment variable, the console will print this...
```
── web_tool_script_1.R ────────────────────────────────────────────────────────────────
```