### PR TITLE
move manual parameter fixes after stress test runs

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -17,19 +17,6 @@ set_portfolio_parameters(file_path = fs::path(par_file_path, paste0(portfolio_na
 
 set_project_parameters(file.path(working_location, "parameter_files",paste0("ProjectParameters_", project_code, ".yml")))
 
-if(project_code == "PA2020FL"){
-  peer_group = case_when(
-    peer_group %in% c("other")~ "Others",
-    peer_group %in% c("bank", "assetmanager") ~ "Banks  and  Asset Managers",
-    peer_group %in% c("pensionfund", "insurance") ~ "Pension Funds  and  Insurances"
-  )
-
-}
-
-if(project_code == "GENERAL"){
-  language_select = "EN"
-}
-
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 
 
@@ -50,6 +37,21 @@ tryCatch(
   source(file.path(stress_test_path, "web_tool_external_stress_test.R")),
   error = function(e) { failed_stress_test_run <<- TRUE; msg <- "an error in web_tool_external_stress_test.R occurred"; print(msg); log_user_errors(msg); }
 )
+
+
+# fix parameters ----------------------------------------------------------
+
+if(project_code == "PA2020FL"){
+  peer_group = case_when(
+    peer_group %in% c("other")~ "Others",
+    peer_group %in% c("bank", "assetmanager") ~ "Banks  and  Asset Managers",
+    peer_group %in% c("pensionfund", "insurance") ~ "Pension Funds  and  Insurances"
+  )
+}
+
+if(project_code == "GENERAL"){
+  language_select = "EN"
+}
 
 
 # create interactive report -----------------------------------------------


### PR DESCRIPTION
These "manual" fixes for parameters currently happen before the stress test scripts run.
https://github.com/2DegreesInvesting/PACTA_analysis/blob/c6a61607a83602a70b9471e6585617644bc77626/web_tool_script_3.R#L20-L31

The stress test code now also loads all the parameters itself, which means these "manual" fixes get over-written. This PR moves them after the stress test code runs so that they are re-"fixed" before the rest of the code runs and the interactive report. This fixes PA2020FL portfolios that currently are not attributed to the correct peer groups.