### PR TITLE
only report invalid holdings that are directly held

### DIFF
--- a/0_json_functions.R
+++ b/0_json_functions.R
@@ -352,6 +352,7 @@ export_audit_graph_json <- function(audit_file__, export_path_full) {
 
 export_audit_invalid_data <- function(portfolio_total_, export_path_full) {
   portfolio_total_ <- portfolio_total_ %>% subset(flag %in% c("Missing currency information", "Negative or missing input value", "Invalid or missing ISIN"))
+  portfolio_total_ <- filter(portfolio_total_, direct_holding == TRUE)
   portfolio_total_ <- portfolio_total_ %>% select("isin", "market_value", "currency", "flag")
   portfolio_total_ <- portfolio_total_[order(-portfolio_total_$market_value), ]
 


### PR DESCRIPTION
This PR removes all indirect holdings from the `invalidsecurities.csv`

Background:

Including indirect holdings (i.e. holdings that are added by merging our fund data) in the `invalidsecurities.csv` causes a lot of confusion with users. First, whatever value is in the `isin` column for an indirect holding will not be found in the original portfolio CSV, so a user is left to understand somehow that it must be some component of a fund in their portfolio (which, frankly, is unrealistic that they will understand that). Secondly, our fund data requires each fund to have a full 100% weight, so if the original data from Lipper, or other source, does not have the full composition of a fund (very common) then we add a line with "MISSINGWEIGHT" or "MISSINGVALUE" or some variation of that to make up for the difference in the total weight of the fund, so it is very common for a user's `invalidsecurities.csv` to be full of lines with an `isin` of "MISSINGWEIGHT" and they have no realistic way of understanding what that means or why it is there (according to @catarinabrg this is a **VERY** frequent problem with COP participants and causes an enormous amount of questions, feedback, and general angst). Thirdly, the original data from Lipper, or other source, often contains fund components that are not ISINs, but rather one of "Cash", "Tax", "Fees", "Gold", etc. (also very common) and so the user also typically gets a `invalidsecurities.csv` full of lines with these variations as well in the `isin` column, which likewise causes a lot of confusion and questions. Fourthly, the original data from Lipper, or other source, can contain ISINs that are not valid, either because it's bogus data or because it's an ISIN that we don't know about in our financial data, leading to the `invalidsecurities.csv` having rows with ISINs that do not appear in the user's original portfolio CSV, causing confusion with the user because they don't understand why these seemingly random holdings have been added to their portfolio.

Originally, @catarinabrg and @cjyetman had considered adding columns to the `invalidsecurities.csv`, like `direct_holding` and/or `fund_isin`, with the goal of maybe making it more obvious to an astute user that those questionable rows are components of one the funds that they directly hold and was included in their portfolio CSV, and hopefully assume that they should not worry about it and not submit angsty questions about why there are all these weird holdings that we've added to their portfolio. After testing that out a bit, and also realizing how many variations of indirect holdings can show up in the `invalidsecurities.csv`, I don't believe adding these columns is really going to improve the situation.

The goal of the `invalidsecurities.csv` is to allow the user to quickly see the holdings that they submitted that we were unable to process for one reason or another, and give them the opportunity to review that and possibly resubmit their portfolio with fixes if possible. There is nothing that a user will ever be able to do about or fix an "invalid" security that is an indirect holding, because indirect holdings are only ever added by merging in our fund data, so they will never be in the user's original portfolio CSV. So I have come to the conclusion that the sensible thing to do is simply not show any indirect holdings in the `invalidsecurities.csv` at all. They only add confusion, and there's nothing a user will ever be able to do with that information. Additionally, the `audit.csv` will continue to have these holdings, along with more columns/data/information to contextualize what they are, e.g. the `direct_holding` which will be `FALSE`.

I do however suspect that this could be a controversial decision, so I think that we should ask as many people on the PACTA team as is feasible before merging this.

For example, this is the current `invalidsecurities.csv` that is generated for one of our test portfolios...
| isin                          | marketValues | currency | flag                                 |
| ------------------ | -------------  | --------- | ---------------------- |
| WeightGapMarker | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| NA                           | 477                  | EUR         | Invalid or missing ISIN |
| MISSINGWEIGHT  | 477                  | EUR         | Invalid or missing ISIN |
