### PR TITLE
suppres warning when coercing to numeric causing NAs that is already …

### DIFF
--- a/0_portfolio_input_check_functions.R
+++ b/0_portfolio_input_check_functions.R
@@ -101,7 +101,7 @@ clean_portfolio_col_types <- function(portfolio, grouping_variables) {
       ),
       file_path = log_path)
     }
-    portfolio$number_of_shares <- as.numeric(portfolio$number_of_shares)
+    portfolio$number_of_shares <- suppressWarnings(as.numeric(portfolio$number_of_shares))
 
   }
   if (is.character(portfolio$currency) == FALSE) {


### PR DESCRIPTION
…logged

Since the warning is already logged with `write_log()`, there's no reason to print this additional warning about coercion to numeric resulting in NAs, so the `as.numeric(portfolio$number_of_shares)` is now wrapped in a `suppressWarnings()`
https://github.com/2DegreesInvesting/PACTA_analysis/blob/c1567f836c4e20816e43e6ec78cbb871c74f3f6b/0_portfolio_input_check_functions.R#L95-L106