### PR TITLE
improve `{testthat}` CI

### DIFF
--- a/.github/workflows/testthat-test_local.yml
+++ b/.github/workflows/testthat-test_local.yml
@@ -30,21 +30,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - name: Install dependencies
-        shell: Rscript {0}
-        run: install.packages(c("cli", "config", "devtools", "dplyr", "fs", "fst", "glue", "here", "janitor", "knitr", "purrr", "readr", "remotes", "rmarkdown", "testthat", "tibble", "tidyr", "withr", "yaml", "zoo"))
-
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+      - uses: r-lib/actions/setup-r-dependencies@v2
 
       - name: run testthat::test_local()
         run: testthat::test_local()


### PR DESCRIPTION
- use v2 r-lib/actions
- update options for v2 actions
- install R pkg dependencies based on DESCRIPTION rather than manually with `r-lib/actions/setup-r-dependencies@v2`
- don't need to install system dependencies manually