### PR TITLE
adjust PA2021LU parameters

### DIFF
--- a/parameter_files/ProjectParameters_PA2021LU.yml
+++ b/parameter_files/ProjectParameters_PA2021LU.yml
@@ -1,5 +1,8 @@
 default:
 
+    paths:
+        data_location_ext: ../pacta-data/2020Q4/
+
     reporting:
         project_report_name: luxembourg
         display_currency: EUR
@@ -7,7 +10,7 @@ default:
 
     parameters:
         timestamp: 2020Q4
-        dataprep_timestamp: 2020Q4_05172021_2020
+        dataprep_timestamp: 2020Q4_transitionmonitor
         start_year: 2021
         horizon_year: 5
         select_scenario: WEO2019_SDS


### PR DESCRIPTION
adjust PA2021LU parameters so it uses the 2020Q4 data

@catarinabrg you may also want to adjust the exchange rate, which is currently 1.22. I don't know what the reasoning behind it is, but I can image...
1. you want the currency exchange rate to match the rate that the original portfolio values are  converted to `value_usd`, i.e. the exchange rate at the same date as the portfolio data (Dec 31, 2020)
2. you want the current exchange rate, so the the report is shown based on the current exchange rate between USD and the target currency
🤷🏻 