### PR TITLE
Meta report data creator

### DIFF
--- a/meta_report_data_creator/combine_portfolios.R
+++ b/meta_report_data_creator/combine_portfolios.R
@@ -391,7 +391,7 @@ lapply(data_filenames, function(data_filename) {
   all_result_filepaths <- setNames(all_result_filepaths, sub(paste0("^", project_prefix, "_port_"), "", basename(dirname(all_result_filepaths))))
 
   all_results <-
-    map_df(all_result_filepaths, readRDS, .id = "portfolio_id") %>%
+    map_df(all_result_filepaths, function(x) { df <- readRDS(x); df$portfolio_name <- as.character(df$portfolio_name); df}, .id = "portfolio_id") %>%
     mutate(portfolio_name = portfolio_id) %>%
     left_join(mutate(portfolios_meta, id = as.character(id)) %>% select(portfolio_id = id, user_id), by = "portfolio_id") %>%
     mutate(investor_name = user_id) %>%
@@ -412,7 +412,7 @@ lapply(data_filenames, function(data_filename) {
   meta_result_filepaths <- list.files(meta_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   all_result_filepaths <- c(portfolio_result_filepaths, meta_result_filepaths)
 
-  all_results <- map_df(all_result_filepaths, readRDS)
+  all_results <- map_df(all_result_filepaths, function(x) { df <- readRDS(x); df$portfolio_name <- as.character(df$portfolio_name); df})
   saveRDS(all_results, file.path(combined_portfolio_results_output_dir, "30_Processed_inputs", data_filename))
 })
 

--- a/meta_report_data_creator/combine_portfolios.R
+++ b/meta_report_data_creator/combine_portfolios.R
@@ -388,13 +388,19 @@ lapply(data_filenames, function(data_filename) {
   portfolio_result_filepaths <- list.files(ports_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   meta_result_filepaths <- list.files(meta_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   all_result_filepaths <- c(portfolio_result_filepaths, meta_result_filepaths)
-  all_result_filepaths <- setNames(all_result_filepaths, sub(paste0("^", project_prefix, "_port_"), "", basename(dirname(all_result_filepaths))))
+  all_result_filepaths <- setNames(
+    all_result_filepaths,
+    c(
+      sub(paste0("^", project_prefix, "_port_"), "", basename(dirname(portfolio_result_filepaths))),
+      "Meta Portfolio"
+    )
+  )
 
   all_results <-
     map_df(all_result_filepaths, function(x) { df <- readRDS(x); df$portfolio_name <- as.character(df$portfolio_name); df}, .id = "portfolio_id") %>%
     mutate(portfolio_name = portfolio_id) %>%
     left_join(mutate(portfolios_meta, id = as.character(id)) %>% select(portfolio_id = id, user_id), by = "portfolio_id") %>%
-    mutate(investor_name = user_id) %>%
+    mutate(investor_name = if_else(portfolio_name == "Meta Portfolio", "Meta Investor", as.character(user_id))) %>%
     select(-portfolio_id, -user_id)
 
   saveRDS(all_results, file.path(combined_portfolio_results_output_dir, "40_Results", data_filename))

--- a/meta_report_data_creator/combine_portfolios.R
+++ b/meta_report_data_creator/combine_portfolios.R
@@ -418,10 +418,14 @@ lapply(data_filenames, function(data_filename) {
   meta_result_filepaths <- list.files(meta_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   all_result_filepaths <- c(portfolio_result_filepaths, meta_result_filepaths)
 
-  all_results <- map_df(all_result_filepaths, function(x) { df <- readRDS(x); df$portfolio_name <- as.character(df$portfolio_name); df})
+  all_results <- map_df(all_result_filepaths, function(x) {
+    df <- readRDS(x);
+    df$portfolio_name <- as.character(df$portfolio_name);
+    if("portfolio_name_2" %in% colnames(df)) df$portfolio_name_2 <- as.character(df$portfolio_name_2) # Happens only for total_portfolio
+    df
+  })
   saveRDS(all_results, file.path(combined_portfolio_results_output_dir, "30_Processed_inputs", data_filename))
 })
-# TODO: weird bug with portfolio_name_2
 
 # combine all user level results -----------------------------------------------
 
@@ -525,3 +529,4 @@ lapply(data_filenames, function(data_filename) {
   all_results <- map_df(all_result_filepaths, readRDS)
   saveRDS(all_results, file.path(combined_orgtype_results_output_dir, "30_Processed_inputs", data_filename))
 })
+

--- a/meta_report_data_creator/combine_portfolios.R
+++ b/meta_report_data_creator/combine_portfolios.R
@@ -421,7 +421,7 @@ lapply(data_filenames, function(data_filename) {
   all_results <- map_df(all_result_filepaths, function(x) { df <- readRDS(x); df$portfolio_name <- as.character(df$portfolio_name); df})
   saveRDS(all_results, file.path(combined_portfolio_results_output_dir, "30_Processed_inputs", data_filename))
 })
-
+# TODO: weird bug with portfolio_name_2
 
 # combine all user level results -----------------------------------------------
 
@@ -439,14 +439,20 @@ lapply(data_filenames, function(data_filename) {
   portfolio_result_filepaths <- list.files(users_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   meta_result_filepaths <- list.files(meta_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   all_result_filepaths <- c(portfolio_result_filepaths, meta_result_filepaths)
-  all_result_filepaths <- setNames(all_result_filepaths, sub(paste0("^", project_prefix, "_user_"), "", basename(dirname(all_result_filepaths))))
+  all_result_filepaths <- all_result_filepaths <- setNames(
+    all_result_filepaths,
+    c(
+      sub(paste0("^", project_prefix, "_user_"), "", basename(dirname(portfolio_result_filepaths))),
+      "Meta Portfolio"
+    )
+  )
 
   all_results <-
     map_df(all_result_filepaths, readRDS, .id = "user_id") %>%
     mutate(portfolio_name = user_id) %>%
     left_join(mutate(users_meta, id = as.character(id)) %>% select(user_id = id, organization_type), by = "user_id") %>%
     rename(peergroup = organization_type) %>%
-    mutate(investor_name = peergroup) %>%
+    mutate(investor_name = if_else(portfolio_name == "Meta Portfolio", "Meta Investor", peergroup)) %>%
     select(-peergroup, -user_id)
 
   saveRDS(all_results, file.path(combined_user_results_output_dir, "40_Results", data_filename))
@@ -463,14 +469,20 @@ lapply(data_filenames, function(data_filename) {
   portfolio_result_filepaths <- list.files(users_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   meta_result_filepaths <- list.files(meta_output_dir, pattern = data_filename, recursive = TRUE, full.names = TRUE)
   all_result_filepaths <- c(portfolio_result_filepaths, meta_result_filepaths)
-  all_result_filepaths <- setNames(all_result_filepaths, sub(paste0("^", project_prefix, "_user_"), "", basename(dirname(all_result_filepaths))))
+  all_result_filepaths <- all_result_filepaths <- setNames(
+    all_result_filepaths,
+    c(
+      sub(paste0("^", project_prefix, "_user_"), "", basename(dirname(portfolio_result_filepaths))),
+      "Meta Portfolio"
+    )
+  )
 
   all_results <-
     map_df(all_result_filepaths, readRDS, .id = "user_id") %>%
     mutate(portfolio_name = user_id) %>%
     left_join(mutate(users_meta, id = as.character(id)) %>% select(user_id = id, organization_type), by = "user_id") %>%
     rename(peergroup = organization_type) %>%
-    mutate(investor_name = peergroup) %>%
+    mutate(investor_name = if_else(portfolio_name == "Meta Portfolio", "Meta Investor", peergroup)) %>%
     select(-c(peergroup, user_id))
 
   saveRDS(all_results, file.path(combined_user_results_output_dir, "30_Processed_inputs", data_filename))


### PR DESCRIPTION
Fixed some minor things when combining the outputs including:

- On portfolio-level when merging the meta portfolio with the rest an error occurred, because portfolio_name for an individual portfolio was type double, but for the meta portfolio was type character
- The naming of meta investor and portfolio was standardized to "Meta Investor" and "Meta Portfolio" to be in agreement with the standard 2dii-naming. This also fixed that in the meta portfolio case often the meta_investor - column was NA.