### PR TITLE
Add `quit_if_no_pacta_relevant_data()` add use in `web_tool_script_2.R`

### DIFF
--- a/R/quit_if_no_pacta_relevant_data.R
+++ b/R/quit_if_no_pacta_relevant_data.R
@@ -1,0 +1,30 @@
+quit_if_no_pacta_relevant_data <- function(portfolio) {
+  if (!any(portfolio$has_asset_level_data, na.rm = TRUE)) {
+    error_name <- "Portfolio does not have any holdings with PACTA relevant data"
+
+    desc <- paste(
+      "This portfolio does not have any direct or indirect investments in ",
+      "companies for which we have PACTA relevant, asset based company data."
+    )
+
+    action <- paste(
+      "Try uploading a portfolio with PACTA relavant holdings."
+    )
+
+    log_user_errors(
+      error_name = error_name,
+      suggested_action = action,
+      description = desc,
+      immediate = TRUE
+    )
+
+    if (!interactive()) {
+      # using message and quit, rather than stop(), because server silently fails
+      # if docker container exits with anything other than a 0 status code
+      message("port_holdings_date contains multiple distinct values")
+      quit(save = "no", status = 0L, runLast = FALSE)
+    }
+
+    stop("no PACTA relevant data")
+  }
+}

--- a/R/quit_if_no_pacta_relevant_data.R
+++ b/R/quit_if_no_pacta_relevant_data.R
@@ -8,7 +8,7 @@ quit_if_no_pacta_relevant_data <- function(portfolio) {
     )
 
     action <- paste(
-      "Try uploading a portfolio with PACTA relavant holdings."
+      "Try uploading a portfolio with PACTA relevant holdings."
     )
 
     log_user_errors(

--- a/R/quit_if_no_pacta_relevant_data.R
+++ b/R/quit_if_no_pacta_relevant_data.R
@@ -21,7 +21,7 @@ quit_if_no_pacta_relevant_data <- function(portfolio) {
     if (!interactive()) {
       # using message and quit, rather than stop(), because server silently fails
       # if docker container exits with anything other than a 0 status code
-      message("port_holdings_date contains multiple distinct values")
+      message("Portfolio does not have any holdings with PACTA relevant data")
       quit(save = "no", status = 0L, runLast = FALSE)
     }
 

--- a/tests/testthat/test-quit_if_no_pacta_relevant_data.R
+++ b/tests/testthat/test-quit_if_no_pacta_relevant_data.R
@@ -12,6 +12,7 @@ test_that("`quit_if_no_pacta_relevant_data()` quits if no ABCD in non-interactiv
         log_path <<- outputs_path
         report_path <- file.path(outputs_path, portfolio_name_ref_all, "report")
         dir.create(path = report_path, recursive = TRUE)
+        setwd(here::here())
         quit_if_no_pacta_relevant_data(port_with_no_data)
         TRUE
       },

--- a/tests/testthat/test-quit_if_no_pacta_relevant_data.R
+++ b/tests/testthat/test-quit_if_no_pacta_relevant_data.R
@@ -1,25 +1,24 @@
 test_that("`quit_if_no_pacta_relevant_data()` quits if no ABCD in non-interactive", {
+  tmp_dir <- withr::local_tempdir()
+  port_name <- "TestPort"
   expect_null({
-    callr::r(function() {
-      devtools::load_all()
-      source(here::here("0_global_functions.R"))
-      port_with_no_data <- data.frame(has_asset_level_data = FALSE)
-      outputs_path <<- tempdir()
-      portfolio_name_ref_all <<- "TestPort"
-      log_path <<- outputs_path
-      dir.create(
-        path = file.path(outputs_path, portfolio_name_ref_all, "report"),
-        recursive = TRUE
-      )
-      dir.create(
-        path = file.path("inst", "rmd"),
-        recursive = TRUE
-      )
-      file.copy(here::here("inst/rmd/user_errors.Rmd"), "inst/rmd/user_errors.Rmd")
-      quit_if_no_pacta_relevant_data(port_with_no_data)
-      TRUE
-    })
+    callr::r(
+      func = function(tmp_dir, port_name) {
+        devtools::load_all()
+        source(here::here("0_global_functions.R"))
+        port_with_no_data <- data.frame(has_asset_level_data = FALSE)
+        outputs_path <<- tmp_dir
+        portfolio_name_ref_all <<- port_name
+        log_path <<- outputs_path
+        report_path <- file.path(outputs_path, portfolio_name_ref_all, "report")
+        dir.create(path = report_path, recursive = TRUE)
+        quit_if_no_pacta_relevant_data(port_with_no_data)
+        TRUE
+      },
+      args = list(tmp_dir, port_name)
+    )
   })
+  expect_true(file.exists(file.path(tmp_dir, port_name, "report", "user_errors.json")))
 })
 
 test_that("`quit_if_no_pacta_relevant_data()` passes if has ABCD in non-interactive", {

--- a/tests/testthat/test-quit_if_no_pacta_relevant_data.R
+++ b/tests/testthat/test-quit_if_no_pacta_relevant_data.R
@@ -1,4 +1,6 @@
 test_that("`quit_if_no_pacta_relevant_data()` quits if no ABCD in non-interactive", {
+  skip_if_R_CMD_check()
+
   tmp_dir <- withr::local_tempdir()
   port_name <- "TestPort"
   expect_null({
@@ -23,6 +25,8 @@ test_that("`quit_if_no_pacta_relevant_data()` quits if no ABCD in non-interactiv
 })
 
 test_that("`quit_if_no_pacta_relevant_data()` passes if has ABCD in non-interactive", {
+  skip_if_R_CMD_check()
+
   expect_true({
     callr::r(function() {
       devtools::load_all()

--- a/tests/testthat/test-quit_if_no_pacta_relevant_data.R
+++ b/tests/testthat/test-quit_if_no_pacta_relevant_data.R
@@ -1,0 +1,47 @@
+test_that("`quit_if_no_pacta_relevant_data()` quits if no ABCD in non-interactive", {
+  expect_null({
+    callr::r(function() {
+      devtools::load_all()
+      source(here::here("0_global_functions.R"))
+      port_with_no_data <- data.frame(has_asset_level_data = FALSE)
+      outputs_path <<- tempdir()
+      portfolio_name_ref_all <<- "TestPort"
+      log_path <<- outputs_path
+      dir.create(
+        path = file.path(outputs_path, portfolio_name_ref_all, "report"),
+        recursive = TRUE
+      )
+      dir.create(
+        path = file.path("inst", "rmd"),
+        recursive = TRUE
+      )
+      file.copy(here::here("inst/rmd/user_errors.Rmd"), "inst/rmd/user_errors.Rmd")
+      quit_if_no_pacta_relevant_data(port_with_no_data)
+      TRUE
+    })
+  })
+})
+
+test_that("`quit_if_no_pacta_relevant_data()` passes if has ABCD in non-interactive", {
+  expect_true({
+    callr::r(function() {
+      devtools::load_all()
+      source(here::here("0_global_functions.R"))
+      port_with_no_data <- data.frame(has_asset_level_data = TRUE)
+      outputs_path <<- tempdir()
+      portfolio_name_ref_all <<- "TestPort"
+      log_path <<- outputs_path
+      dir.create(
+        path = file.path(outputs_path, portfolio_name_ref_all, "report"),
+        recursive = TRUE
+      )
+      dir.create(
+        path = file.path("inst", "rmd"),
+        recursive = TRUE
+      )
+      file.copy(here::here("inst/rmd/user_errors.Rmd"), "inst/rmd/user_errors.Rmd")
+      quit_if_no_pacta_relevant_data(port_with_no_data)
+      TRUE
+    })
+  })
+})

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -35,6 +35,18 @@ create_portfolio_subfolders(portfolio_name_ref_all)
 
 port_col_types <- set_col_types(grouping_variables, "ddddccccddclc")
 
+
+# quit if there's no relevant PACTA assets --------------------------------
+
+ttlport <- file.path(proc_input_path, portfolio_name_ref_all, "total_portfolio.rda")
+if (file.exists(ttlport)) {
+  ttlport <- readRDS(ttlport)
+  quit_if_no_pacta_relevant_data(ttlport)
+} else {
+  warning("This is weird... the `total_portfolio.rda` file does not exist in the `30_Processed_inputs` directory.")
+}
+
+
 ##################
 ##### EQUITY #####
 ##################

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -38,10 +38,10 @@ port_col_types <- set_col_types(grouping_variables, "ddddccccddclc")
 
 # quit if there's no relevant PACTA assets --------------------------------
 
-ttlport <- file.path(proc_input_path, portfolio_name_ref_all, "total_portfolio.rda")
-if (file.exists(ttlport)) {
-  ttlport <- readRDS(ttlport)
-  quit_if_no_pacta_relevant_data(ttlport)
+total_portfolio_path <- file.path(proc_input_path, portfolio_name_ref_all, "total_portfolio.rda")
+if (file.exists(total_portfolio_path)) {
+  total_portfolio <- readRDS(total_portfolio_path)
+  quit_if_no_pacta_relevant_data(total_portfolio)
 } else {
   warning("This is weird... the `total_portfolio.rda` file does not exist in the `30_Processed_inputs` directory.")
 }


### PR DESCRIPTION
The goal of this is to stop the process during the report generation phase that occurs when a user on TM clicks the "View report" or "View Exec Summary" button, which triggers the running of web_tool_script_2.R and web_tool_script_3.R. It's intended to use the same infrastructure that @AlexAxthelm created to stop and display an error if there are different holding dates in a grouped portfolio. To achieve its goal on the TM server, it needs to make R quit but with a exit code of 0, and it also needs to drop an HTML page in the right location.

Doing this check as soon as possible in web_tool_script_2.R seems like the right thing to do, to avoid to any of the potential heavy processing of matching ABCD etc., though I suppose if the portfolio doesn't have any PACTA relevant holdings it won't take long to process. However, at least currently because of [this issue](https://github.com/2DegreesInvesting/PACTA_analysis/issues/625), the TDM processing will error out, so at least at the moment, this break needs to happen early in the process before any TDM is calculated.