### PR TITLE
Remove LazyData option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,6 @@ Suggests:
     withr,
     yaml
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.0
 Config/testthat/edition: 3


### PR DESCRIPTION
Removes `LazyData: true` option from DESCRIPTION, which is intended for packages that combine all included data files in a single `R/sysdata.rda` file (e.g. [see here](https://usethis.r-lib.org/reference/use_data.html)), which this package currently does *not*... even if conceptually that might be a preferable option. This will avoid the R CMD check warning "Omitted ‘LazyData’ from DESCRIPTION".