### PR TITLE
force quit report generation if no PACTA relevant data exists

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -20,6 +20,17 @@ set_project_parameters(file.path(working_location, "parameter_files",paste0("Pro
 analysis_inputs_path <- set_analysis_inputs_path(twodii_internal, data_location_ext, dataprep_timestamp)
 
 
+# quit if there's no relevant PACTA assets --------------------------------
+
+total_portfolio_path <- file.path(proc_input_path, portfolio_name_ref_all, "total_portfolio.rda")
+if (file.exists(total_portfolio_path)) {
+  total_portfolio <- readRDS(total_portfolio_path)
+  quit_if_no_pacta_relevant_data(total_portfolio)
+} else {
+  warning("This is weird... the `total_portfolio.rda` file does not exist in the `30_Processed_inputs` directory.")
+}
+
+
 # stress test -------------------------------------------------------------
 
 # provide parameters for stress test


### PR DESCRIPTION
related to #626 and ADO-1369

Code was added to [web_tool_script_2.R](https://github.com/2DegreesInvesting/PACTA_analysis/blob/46ee4a74b6903acd3beeb6e4a7d5c32e2a86aa80/web_tool_script_2.R#L39-L47) to force quit if there's no relevant PACTA data to analyze, primarily to give the TM server the chance to stop and create the user error HTML file and avoid The Infinite Cog™️. It appears that after stopping web_tool_script_2.R and creating the user error HTML, the server then runs web_tool_script_3.R anyway, which then attempts to generate the report with no relevant data, which works without and error or The Infinite Cog™️, but the result is a nearly empty report and no obvious explanation of why it is nearly empty.

Adding the same force stop code to web_tool_script_3.R should make the server stop the report generation and over-writing the user error HTML so the intended effect will happen.

If this works, I suppose this fix should also be added to the new [pacta.data.preparation](https://github.com/2DegreesInvesting/pacta.data.preparation) repo also (https://github.com/2DegreesInvesting/pacta.portfolio.analysis/issues/35).